### PR TITLE
Store URL as String so that environment variables can be substituted

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.536</version>
+        <version>1.509.4</version>
     </parent>
     
     <artifactId>http_request</artifactId>


### PR DESCRIPTION
I wanted to perform a `POST` against `$JENKINS_URL/safeRestart` but couldn't because the `HttpRequestValidation.checkUrl()` failed it. I changed the URL to not be validated but instead being stored as a `String`. Now the environment variables can be substituted.

Also, made the jenkins version earlier. This is the current plugin archetype default and so more people would be able to use the plugin.
