### PR TITLE
Adding support to not log out the response body.

### DIFF
--- a/src/main/java/jenkins/plugins/http_request/util/HttpClientUtil.java
+++ b/src/main/java/jenkins/plugins/http_request/util/HttpClientUtil.java
@@ -66,13 +66,15 @@ public class HttpClientUtil {
     }
 
     public HttpResponse execute(DefaultHttpClient client, HttpRequestBase method,
-            PrintStream logger) throws IOException {
+            PrintStream logger, boolean logResponseBody) throws IOException {
         doSecurity(client, method.getURI());
 
         logger.println("Sending request to url: " + method.getURI());
         final HttpResponse execute = client.execute(method);
         logger.println("Response Code: " + execute.getStatusLine());
-        logger.println("Response: \n" + EntityUtils.toString(execute.getEntity()));
+	if (logResponseBody){
+	    logger.println("Response: \n" + EntityUtils.toString(execute.getEntity()));
+	}
         
         EntityUtils.consume(execute.getEntity());
 

--- a/src/main/resources/jenkins/plugins/http_request/HttpRequest/config.jelly
+++ b/src/main/resources/jenkins/plugins/http_request/HttpRequest/config.jelly
@@ -15,4 +15,8 @@
         <f:select />
     </f:entry>
 
+    <f:entry field="logResponseBody" title="Log Response Body?">
+        <f:select />
+    </f:entry>   
+    
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/http_request/HttpRequest/global.jelly
+++ b/src/main/resources/jenkins/plugins/http_request/HttpRequest/global.jelly
@@ -91,5 +91,11 @@
                  help="/plugin/http_request/WEB-INF/classes/jenkins/plugins/http_request/HttpRequest/help-returnCodeBuildRelevant.html">
             <f:booleanRadio />
         </f:entry>
+
+        <f:entry field="defaultLogResponseBody" title="Log Response body by default?"
+                 help="/plugin/http_request/WEB-INF/classes/jenkins/plugins/http_request/HttpRequest/help-logResponseBody.html">
+            <f:booleanRadio />
+        </f:entry>
+	
     </f:section>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/http_request/HttpRequest/help-logBodyResponse.html
+++ b/src/main/resources/jenkins/plugins/http_request/HttpRequest/help-logBodyResponse.html
@@ -1,0 +1,3 @@
+<div>
+    This allows you to turn off writing the response body to the log.
+</div>


### PR DESCRIPTION
This will allow you to prevent the response body from being added to the build log in jenkins.  There is a global and project specific setting that controls if the response body will get written to the build logs.  By default it will write to the build logs, so it should not cause issues for existing users.  All we needed to know is that the response code was a 200, and did not care about the payload of the page.  Not sure if this would be helpful to others, but we did not want to bloat our build logs.
