### PR TITLE
Check for nullity on passBuildParameters

### DIFF
--- a/src/main/java/jenkins/plugins/http_request/HttpRequest.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequest.java
@@ -343,7 +343,7 @@ public class HttpRequest extends Builder {
     private List<HttpRequestNameValuePair> createParameters(
             AbstractBuild<?, ?> build, PrintStream logger,
             EnvVars envVars) {
-        if (!passBuildParameters) {
+        if (passBuildParameters == null || !passBuildParameters) {
             return Collections.emptyList();
         }
 


### PR DESCRIPTION
This is quite a corner case, but passBuildParameters can be null if not written at all to the config.xml (eg. programmatic job configuration through Job DSL Plugin).