### PR TITLE
Add setting to ignore a refused connection.

### DIFF
--- a/src/main/resources/jenkins/plugins/http_request/HttpRequest/config.jelly
+++ b/src/main/resources/jenkins/plugins/http_request/HttpRequest/config.jelly
@@ -36,6 +36,9 @@
             <f:entry field="timeout" title="Connection timeout" help="/plugin/http_request/help-timeout.html">
                 <f:number default="${descriptor.timeout}"/>
             </f:entry>
+            <f:entry field="ignoreConnectException" title="Ignore refused connection" help="/plugin/http_request/help-connection-refused.html">
+            	<f:booleanRadio />
+        	</f:entry>
             <f:entry field="validResponseCodes" title="Response codes expected" help="/plugin/http_request/help-validResponseCodes.html">
                 <f:textbox default="${descriptor.validResponseCodes}"/>
             </f:entry>

--- a/src/main/resources/jenkins/plugins/http_request/HttpRequestStep/config.jelly
+++ b/src/main/resources/jenkins/plugins/http_request/HttpRequestStep/config.jelly
@@ -23,6 +23,9 @@
         <f:entry field="timeout" title="Connection timeout" help="/plugin/http_request/help-timeout.html">
             <f:number default="${descriptor.timeout}"/>
         </f:entry>
+        <f:entry field="ignoreConnectException" title="Ignore refused connection" help="/plugin/http_request/help-connection-refused.html">
+            <f:booleanRadio />
+        </f:entry>
         <f:entry field="consoleLogResponseBody" title="Response body in console?" help="/plugin/http_request/help-consoleLogResponseBody.html">
             <f:booleanRadio />
         </f:entry>

--- a/src/main/webapp/help-connection-refused.html
+++ b/src/main/webapp/help-connection-refused.html
@@ -1,0 +1,3 @@
+<div>
+    If true, this step succeeds even if it was not possible to open a connection to remote host.
+</div>


### PR DESCRIPTION
In our case we need to call a url in order to tell the load balancer to stop routing new requests to a server. In some cases the server is not running which results to the connection being refused and a failed build. We needed a way to proceed with the build.

Please decide whether you find this usefull as well.