### PR TITLE
Resolve parameters that are set in the request body or in custom head…

### DIFF
--- a/src/main/java/jenkins/plugins/http_request/HttpRequest.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequest.java
@@ -328,7 +328,8 @@ public class HttpRequest extends Builder {
         }
 
         for (HttpRequestNameValuePair header : customHeaders) {
-            httpRequestBase.addHeader(header.getName(), header.getValue());
+            String value = HttpClientUtil.resolveParameters(header.getValue(), requestAction.getParams());
+            httpRequestBase.addHeader(header.getName(), value);
         }
         return httpRequestBase;
     }

--- a/src/main/java/jenkins/plugins/http_request/util/HttpClientUtil.java
+++ b/src/main/java/jenkins/plugins/http_request/util/HttpClientUtil.java
@@ -57,17 +57,9 @@ public class HttpClientUtil {
     private HttpEntity makeEntity(RequestAction requestAction) throws
             UnsupportedEncodingException {
         if (!Strings.isNullOrEmpty(requestAction.getRequestBody())) {
-            String requestBody = resolveParameters(requestAction.getRequestBody(), requestAction.getParams());
-            return new StringEntity(requestBody);
+        	return new StringEntity(requestAction.getRequestBody());
         }
         return new UrlEncodedFormEntity(requestAction.getParams());
-    }
-
-    public static String resolveParameters(String inStr, List<HttpRequestNameValuePair> params) {
-        for (HttpRequestNameValuePair param : params)
-            inStr = inStr.replaceAll("\\$\\{" + param.getName() + "\\}", param.getValue());
-
-        return inStr;
     }
 
     public HttpGet makeGet(RequestAction requestAction) throws IOException {

--- a/src/main/java/jenkins/plugins/http_request/util/HttpClientUtil.java
+++ b/src/main/java/jenkins/plugins/http_request/util/HttpClientUtil.java
@@ -57,9 +57,17 @@ public class HttpClientUtil {
     private HttpEntity makeEntity(RequestAction requestAction) throws
             UnsupportedEncodingException {
         if (!Strings.isNullOrEmpty(requestAction.getRequestBody())) {
-            return new StringEntity(requestAction.getRequestBody());
+            String requestBody = resolveParameters(requestAction.getRequestBody(), requestAction.getParams());
+            return new StringEntity(requestBody);
         }
         return new UrlEncodedFormEntity(requestAction.getParams());
+    }
+
+    public static String resolveParameters(String inStr, List<HttpRequestNameValuePair> params) {
+        for (HttpRequestNameValuePair param : params)
+            inStr = inStr.replaceAll("\\$\\{" + param.getName() + "\\}", param.getValue());
+
+        return inStr;
     }
 
     public HttpGet makeGet(RequestAction requestAction) throws IOException {

--- a/src/main/webapp/help-requestBody.html
+++ b/src/main/webapp/help-requestBody.html
@@ -1,3 +1,4 @@
 <div>
-    The raw body of the request.
+    <p>The raw body of the request.</p>
+    <p>Parameters will be resolved.</p>
 </div>

--- a/src/test/java/jenkins/plugins/http_request/HttpRequestTest.java
+++ b/src/test/java/jenkins/plugins/http_request/HttpRequestTest.java
@@ -171,6 +171,40 @@ public class HttpRequestTest extends HttpRequestTestBase {
     }
 
     @Test
+    public void replaceParametersInRequestBody() throws Exception {
+
+    	// Prepare the server
+        final HttpHost target = start();
+        final String baseURL = "http://localhost:" + target.getPort();
+
+        // Prepare HttpRequest
+        HttpRequest httpRequest = new HttpRequest(baseURL+"/checkRequestBodyWithTag");
+        httpRequest.setConsoleLogResponseBody(true);
+
+        // Activate requsetBody
+        httpRequest.setHttpMode(HttpMode.POST);
+        
+        // Use some random body content that contains a parameter
+        httpRequest.setRequestBody("cleanupDir=D:/continuousIntegration/deployments/Daimler/${Tag}/standalone");
+        
+        // Build parameters have to be passed
+        httpRequest.setPassBuildParameters(true);
+
+        // Run build
+        FreeStyleProject project = j.createFreeStyleProject();
+        project.getBuildersList().add(httpRequest);
+        
+        FreeStyleBuild build = project.scheduleBuild2(0,
+                new UserIdCause(),
+                new ParametersAction(new StringParameterValue("Tag","trunk"))
+            ).get();
+        
+        // Check expectations
+        j.assertBuildStatusSuccess(build);
+        j.assertLogContains(allIsWellMessage,build);
+    }
+    
+    @Test
     public void silentlyIgnoreNonExistentBuildParameters() throws Exception {
         // Prepare the server
         final HttpHost target = start();

--- a/src/test/java/jenkins/plugins/http_request/HttpRequestTestBase.java
+++ b/src/test/java/jenkins/plugins/http_request/HttpRequestTestBase.java
@@ -328,7 +328,7 @@ public class HttpRequestTestBase extends LocalServerTestBase {
             }
         });
 
-        // Check the basic authentication header
+        // Check the custom headers
         this.serverBootstrap.registerHandler("/customHeaders", new HttpRequestHandler() {
             @Override
             public void handle(
@@ -341,6 +341,28 @@ public class HttpRequestTestBase extends LocalServerTestBase {
                 assertEquals(2, headers.length);
                 assertEquals("value1", headers[0].getValue());
                 assertEquals("value2", headers[1].getValue());
+                response.setEntity(new StringEntity(allIsWellMessage, ContentType.TEXT_PLAIN));
+            }
+        });
+        
+        // Check if the parameters in custom headers have been resolved
+        this.serverBootstrap.registerHandler("/customHeadersResolved", new HttpRequestHandler() {
+            @Override
+            public void handle(
+                final org.apache.http.HttpRequest request,
+                final HttpResponse response,
+                final HttpContext context
+            ) throws HttpException, IOException {
+                Header[] headers = request.getAllHeaders();
+
+                headers = request.getHeaders("resolveCustomParam");
+                assertEquals(1, headers.length);
+                assertEquals("trunk", headers[0].getValue());
+                
+                headers = request.getHeaders("resolveEnvParam");
+                assertEquals(1, headers.length);
+                assertEquals("C:/path/to/my/workspace", headers[0].getValue());
+                
                 response.setEntity(new StringEntity(allIsWellMessage, ContentType.TEXT_PLAIN));
             }
         });

--- a/src/test/java/jenkins/plugins/http_request/HttpRequestTestBase.java
+++ b/src/test/java/jenkins/plugins/http_request/HttpRequestTestBase.java
@@ -197,6 +197,28 @@ public class HttpRequestTestBase extends LocalServerTestBase {
             }
         });
 
+        // Check that request body is present and that the containing parameter ${Tag} has been resolved to "trunk"
+        this.serverBootstrap.registerHandler("/checkRequestBodyWithTag", new HttpRequestHandler() {
+            @Override
+            public void handle(
+                    final org.apache.http.HttpRequest request,
+                    final HttpResponse response,
+                    final HttpContext context
+            ) throws HttpException, IOException {
+                assertEquals("POST", request.getRequestLine().getMethod());
+                String requestBody = null;
+                if (request instanceof HttpEntityEnclosingRequest) {
+                    HttpEntity entity = ((HttpEntityEnclosingRequest) request).getEntity();
+                    if (entity != null) {
+                        requestBody = EntityUtils.toString(entity, "UTF-8");
+                        entity.consumeContent();
+                    }
+                }
+                assertEquals("cleanupDir=D:/continuousIntegration/deployments/Daimler/trunk/standalone",requestBody);
+                response.setEntity(new StringEntity(allIsWellMessage, ContentType.TEXT_PLAIN));
+            }
+        });
+        
         // Return an invalid status code
         this.serverBootstrap.registerHandler("/invalidStatusCode", new HttpRequestHandler() {
             @Override


### PR DESCRIPTION
Currently there is no possibility to pass all parameters and a request body to the client.

Use case:
I want to pass the value
D:/jenkins/${Tag}/workspace
in the request body.

There is no possibility to do that, because the parameters are not resolved.

This change will resolve all the parameters within the request body and within custom headers, too.