### PR TITLE
Support set Content-Type encoding for correct send requestBody

### DIFF
--- a/src/main/java/jenkins/plugins/http_request/HttpRequest.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequest.java
@@ -222,7 +222,7 @@ public class HttpRequest extends Builder {
         final List<HttpRequestNameValuePair> headers = new ArrayList<>();
 
         if (contentType != MimeType.NOT_SET) {
-            headers.add(new HttpRequestNameValuePair("Content-type", contentType.getValue()));
+            headers.add(new HttpRequestNameValuePair("Content-type", contentType.getContentType().toString()));
         }
         if (acceptType != MimeType.NOT_SET) {
             headers.add(new HttpRequestNameValuePair("Accept", acceptType.getValue()));
@@ -234,7 +234,7 @@ public class HttpRequest extends Builder {
             headers.add(new HttpRequestNameValuePair(headerName, headerValue));
         }
 
-        RequestAction requestAction = new RequestAction(new URL(evaluatedUrl), httpMode, evaluatedBody, params, headers);
+        RequestAction requestAction = new RequestAction(new URL(evaluatedUrl), httpMode, evaluatedBody, params, headers, contentType.getContentType());
 
         ResponseContentSupplier responseContentSupplier = performHttpRequest(listener, requestAction);
 
@@ -248,7 +248,7 @@ public class HttpRequest extends Builder {
         List<HttpRequestNameValuePair> params = Collections.emptyList();
         List<HttpRequestNameValuePair> headers = new ArrayList<>();
         if (contentType != MimeType.NOT_SET) {
-            headers.add(new HttpRequestNameValuePair("Content-type", contentType.getValue()));
+            headers.add(new HttpRequestNameValuePair("Content-type", contentType.getContentType().toString()));
         }
         if (acceptType != MimeType.NOT_SET) {
             headers.add(new HttpRequestNameValuePair("Accept", acceptType.getValue()));
@@ -257,7 +257,7 @@ public class HttpRequest extends Builder {
             headers.add(new HttpRequestNameValuePair(header.getName(), header.getValue()));
         }
 
-        RequestAction requestAction = new RequestAction(new URL(url), httpMode, requestBody, params, headers);
+        RequestAction requestAction = new RequestAction(new URL(url), httpMode, requestBody, params, headers, contentType.getContentType());
 
         return performHttpRequest(listener, requestAction);
     }

--- a/src/main/java/jenkins/plugins/http_request/MimeType.java
+++ b/src/main/java/jenkins/plugins/http_request/MimeType.java
@@ -1,28 +1,34 @@
 package jenkins.plugins.http_request;
 
 import hudson.util.ListBoxModel;
+import org.apache.http.entity.ContentType;
 
 /**
  * @author James Chapman
  */
 public enum MimeType {
 
-    NOT_SET(""),
-    TEXT_HTML("text/html"),
-    TEXT_PLAIN("text/plain"),
-    APPLICATION_JSON("application/json"),
-    APPLICATION_TAR("application/x-tar"),
-    APPLICATION_ZIP("application/zip"),
-    APPLICATION_OCTETSTREAM("application/octet-stream");
+    NOT_SET(ContentType.create("")),
+    TEXT_HTML(ContentType.TEXT_HTML),
+    TEXT_PLAIN(ContentType.TEXT_PLAIN),
+    APPLICATION_JSON(ContentType.create("application/json")),
+    APPLICATION_JSON_UTF8(ContentType.APPLICATION_JSON),
+    APPLICATION_TAR(ContentType.create("application/x-tar")),
+    APPLICATION_ZIP(ContentType.create("application/zip")),
+    APPLICATION_OCTETSTREAM(ContentType.APPLICATION_OCTET_STREAM);
 
-    private final String value;
+    private final ContentType contentType;
 
-    MimeType(String value) {
-        this.value = value;
+    MimeType(ContentType contentType) {
+        this.contentType = contentType;
     }
 
     public String getValue() {
-        return value;
+        return contentType.getMimeType();
+    }
+
+    public ContentType getContentType() {
+        return contentType;
     }
 
     public static ListBoxModel getContentTypeFillItems() {

--- a/src/main/java/jenkins/plugins/http_request/util/HttpClientUtil.java
+++ b/src/main/java/jenkins/plugins/http_request/util/HttpClientUtil.java
@@ -16,6 +16,7 @@ import org.apache.http.conn.scheme.Scheme;
 import org.apache.http.conn.scheme.SchemeRegistry;
 import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.apache.http.conn.ssl.TrustStrategy;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.protocol.HttpContext;
@@ -70,7 +71,16 @@ public class HttpClientUtil {
     private HttpEntity makeEntity(RequestAction requestAction) throws
             UnsupportedEncodingException {
         if (!Strings.isNullOrEmpty(requestAction.getRequestBody())) {
-        	return new StringEntity(requestAction.getRequestBody());
+            ContentType contentType = requestAction.getContentType();
+            if (contentType == null) {
+                for (HttpRequestNameValuePair header : requestAction.getHeaders()) {
+                    if ("Content-type".equals(header.getName())) {
+                        contentType = ContentType.parse(header.getValue());
+                    }
+                }
+            }
+
+        	  return new StringEntity(requestAction.getRequestBody(), contentType);
         }
         return new UrlEncodedFormEntity(requestAction.getParams());
     }

--- a/src/main/java/jenkins/plugins/http_request/util/RequestAction.java
+++ b/src/main/java/jenkins/plugins/http_request/util/RequestAction.java
@@ -6,6 +6,7 @@ import hudson.model.Descriptor;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import jenkins.plugins.http_request.HttpMode;
+import org.apache.http.entity.ContentType;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
@@ -24,6 +25,7 @@ public class RequestAction extends AbstractDescribableImpl<RequestAction> {
     private final String requestBody;
     private final List<HttpRequestNameValuePair> params;
     private final List<HttpRequestNameValuePair> headers;
+    private ContentType contentType;
 
     @DataBoundConstructor
     public RequestAction(URL url, HttpMode mode, String requestBody, List<HttpRequestNameValuePair> params) {
@@ -31,11 +33,16 @@ public class RequestAction extends AbstractDescribableImpl<RequestAction> {
     }
 
     public RequestAction(URL url, HttpMode mode, String requestBody, List<HttpRequestNameValuePair> params, List<HttpRequestNameValuePair> headers) {
+        this(url, mode, requestBody, params, headers, ContentType.DEFAULT_TEXT);
+    }
+
+    public RequestAction(URL url, HttpMode mode, String requestBody, List<HttpRequestNameValuePair> params, List<HttpRequestNameValuePair> headers, ContentType contentType) {
         this.url = url;
         this.mode = mode;
         this.requestBody = requestBody;
         this.params = params == null ? new ArrayList<HttpRequestNameValuePair>() : params;
         this.headers = headers  == null ? new ArrayList<HttpRequestNameValuePair>() : headers;
+        this.contentType = contentType;
     }
 
     public URL getUrl() {
@@ -56,6 +63,10 @@ public class RequestAction extends AbstractDescribableImpl<RequestAction> {
 
     public String getRequestBody() {
         return requestBody;
+    }
+
+    public ContentType getContentType() {
+        return contentType;
     }
 
     @Extension


### PR DESCRIPTION
Support set Content-Type encoding in APPLICATION_JSON_UTF8 option (backward compatibility) and set content-type with encoding in custom headers. By default JSON in UTF-8 but previous realization is in ISO 8859-1.