### PR TITLE
Mask the Authorization header

### DIFF
--- a/src/main/java/jenkins/plugins/http_request/HttpRequest.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequest.java
@@ -269,7 +269,11 @@ public class HttpRequest extends Builder {
         logger.println("HttpMode: " + requestAction.getMode());
         logger.println(String.format("URL: %s", requestAction.getUrl()));
         for (HttpRequestNameValuePair header : requestAction.getHeaders()) {
-            logger.println(header.getName() + ": " + header.getValue());
+            if (header.getName().equalsIgnoreCase("Authorization")) {
+              logger.println(header.getName() + ": *****");
+            } else {
+              logger.println(header.getName() + ": " + header.getValue());
+            }
         }
 
         DefaultHttpClient httpclient = new SystemDefaultHttpClient();


### PR DESCRIPTION
Address issue [JENKINS-39744](https://issues.jenkins-ci.org/browse/JENKINS-39744) by always masking the “Authorization” header value.

This pipeline script
```groovy
#!groovy

httpRequest httpMode: 'GET',
  url: "https://httpbin.org/get",
  customHeaders: [[name: 'Authorization', value: "Basic dXNlcm5hbWU6cGFzc3dvcmQ="]]
```

Gives this result.
```sh
[Pipeline] httpRequest
HttpMode: GET
URL: https://httpbin.org/get
Authorization: *****
Sending request to url: https://httpbin.org/get
Response Code: HTTP/1.1 200 OK
Success code from [100‥399]
[Pipeline] End of Pipeline
```

instead of echoing the value `Basic dXNlcm5hbWU6cGFzc3dvcmQ=` which is easily decoded into username:password. 