### PR TITLE
Allow masking custom headers

### DIFF
--- a/src/main/java/jenkins/plugins/http_request/HttpRequest.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequest.java
@@ -230,6 +230,7 @@ public class HttpRequest extends Builder {
         for (HttpRequestNameValuePair header : customHeaders) {
             String headerName = evaluate(header.getName(), buildVariableResolver, envVars);
             String headerValue = evaluate(header.getValue(), buildVariableResolver, envVars);
+            boolean maskValue = Boolean.parseBoolean(evaluate(String.valueOf(header.getMaskValue()), buildVariableResolver, envVars));
 
             headers.add(new HttpRequestNameValuePair(headerName, headerValue));
         }
@@ -254,7 +255,7 @@ public class HttpRequest extends Builder {
             headers.add(new HttpRequestNameValuePair("Accept", acceptType.getValue()));
         }
         for (HttpRequestNameValuePair header : customHeaders) {
-            headers.add(new HttpRequestNameValuePair(header.getName(), header.getValue()));
+            headers.add(new HttpRequestNameValuePair(header.getName(), header.getValue(), header.getMaskValue()));
         }
 
         RequestAction requestAction = new RequestAction(new URL(url), httpMode, requestBody, params, headers, contentType.getContentType());
@@ -269,7 +270,7 @@ public class HttpRequest extends Builder {
         logger.println("HttpMode: " + requestAction.getMode());
         logger.println(String.format("URL: %s", requestAction.getUrl()));
         for (HttpRequestNameValuePair header : requestAction.getHeaders()) {
-            if (header.getName().equalsIgnoreCase("Authorization")) {
+            if (header.getMaskValue() || header.getName().equalsIgnoreCase("Authorization")) {
               logger.println(header.getName() + ": *****");
             } else {
               logger.println(header.getName() + ": " + header.getValue());

--- a/src/main/java/jenkins/plugins/http_request/util/HttpRequestNameValuePair.java
+++ b/src/main/java/jenkins/plugins/http_request/util/HttpRequestNameValuePair.java
@@ -17,11 +17,17 @@ public class HttpRequestNameValuePair extends AbstractDescribableImpl<HttpReques
 
     private final String name;
     private final String value;
+    private final boolean maskValue;
 
     @DataBoundConstructor
-    public HttpRequestNameValuePair(String name, String value) {
+    public HttpRequestNameValuePair(String name, String value, boolean maskValue) {
         this.name = name;
         this.value = value;
+        this.maskValue = maskValue;
+    }
+
+    public HttpRequestNameValuePair(String name, String value) {
+        this(name, value, false);
     }
 
     public String getName() {
@@ -30,6 +36,10 @@ public class HttpRequestNameValuePair extends AbstractDescribableImpl<HttpReques
 
     public String getValue() {
         return value;
+    }
+
+    public boolean getMaskValue() {
+        return maskValue;
     }
 
     @Extension

--- a/src/main/resources/jenkins/plugins/http_request/util/HttpRequestNameValuePair/config.jelly
+++ b/src/main/resources/jenkins/plugins/http_request/util/HttpRequestNameValuePair/config.jelly
@@ -6,6 +6,9 @@
     <f:entry title="Value" field="value">
         <f:textbox/>
     </f:entry>
+    <f:entry title="Mask value" field="maskValue" description="If checked, this will mask the value in the logs.">
+        <f:checkbox/>
+    </f:entry>
     <f:entry>
         <div align="right">
             <f:repeatableDeleteButton/>


### PR DESCRIPTION
Would you take this in consideration?

Sometimes custom headers are filled with authentication tokens, and it would be nice if those tokens do not appear in the logs.

This pipeline script:

```
#!groovy

httpRequest httpMode: 'GET', 
       customHeaders: [[name: 'X-Vault-Token', value: vault_token, maskValue: true],[name: 'X-Test', value: 'test']], 
       url: http://vault.default.svc.cluster.local:8200/v1/secret/mySecret
```

would output the folowing in the logs:

```
[Pipeline] httpRequest
HttpMode: GET
URL: http://vault.default.svc.cluster.local:8200/v1/secret/android_debug
Content-type: application/json
X-Vault-Token: *****
X-Test: test
Sending request to url: http://vault.default.svc.cluster.local:8200/v1/secret/mySecret
Response Code: HTTP/1.1 200 OK
Success code from [100‥399]
```

The default behaviour is to not mask the value, so the extra maskValue parameter is only required when you need to mask the value.

I've tested this on my local Jenkins (v 2.32.1) succesfully. I'm not java nor Jenkins plugin developer so it's possible that there is a better way to achieve this, but anyway, here are my two cents. 