### PR TITLE
Add support for http proxy

### DIFF
--- a/src/main/java/jenkins/plugins/http_request/HttpRequest.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequest.java
@@ -57,6 +57,7 @@ public class HttpRequest extends Builder {
     private @Nonnull String url;
 	private Boolean ignoreSslErrors = DescriptorImpl.ignoreSslErrors;
 	private HttpMode httpMode                 = DescriptorImpl.httpMode;
+	private String httpProxyHost              = DescriptorImpl.httpProxyHost;
     private Boolean passBuildParameters       = DescriptorImpl.passBuildParameters;
     private String validResponseCodes         = DescriptorImpl.validResponseCodes;
     private String validResponseContent       = DescriptorImpl.validResponseContent;
@@ -95,6 +96,15 @@ public class HttpRequest extends Builder {
 	@DataBoundSetter
 	public void setHttpMode(HttpMode httpMode) {
 		this.httpMode = httpMode;
+	}
+
+	public String getHttpProxyHost() {
+		return httpProxyHost;
+	}
+
+	@DataBoundSetter
+	public void setHttpProxyHost(String httpProxyHost) {
+		this.httpProxyHost = httpProxyHost;
 	}
 
 	public Boolean getPassBuildParameters() {
@@ -310,6 +320,7 @@ public class HttpRequest extends Builder {
     public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
 		public static final boolean ignoreSslErrors = false;
 		public static final HttpMode httpMode                  = HttpMode.GET;
+		public static final String   httpProxyHost             = "";
         public static final Boolean  passBuildParameters       = false;
         public static final String   validResponseCodes        = "100:399";
         public static final String   validResponseContent      = "";

--- a/src/main/java/jenkins/plugins/http_request/HttpRequest.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequest.java
@@ -57,7 +57,7 @@ public class HttpRequest extends Builder {
     private @Nonnull String url;
 	private Boolean ignoreSslErrors = DescriptorImpl.ignoreSslErrors;
 	private HttpMode httpMode                 = DescriptorImpl.httpMode;
-	private String httpProxyHost              = DescriptorImpl.httpProxyHost;
+	private String httpProxy                  = DescriptorImpl.httpProxy;
     private Boolean passBuildParameters       = DescriptorImpl.passBuildParameters;
     private String validResponseCodes         = DescriptorImpl.validResponseCodes;
     private String validResponseContent       = DescriptorImpl.validResponseContent;
@@ -98,13 +98,13 @@ public class HttpRequest extends Builder {
 		this.httpMode = httpMode;
 	}
 
-	public String getHttpProxyHost() {
-		return httpProxyHost;
+	public String getHttpProxy() {
+		return httpProxy;
 	}
 
 	@DataBoundSetter
-	public void setHttpProxyHost(String httpProxyHost) {
-		this.httpProxyHost = httpProxyHost;
+	public void setHttpProxy(String httpProxy) {
+		this.httpProxy = httpProxy;
 	}
 
 	public Boolean getPassBuildParameters() {
@@ -320,7 +320,7 @@ public class HttpRequest extends Builder {
     public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
 		public static final boolean ignoreSslErrors = false;
 		public static final HttpMode httpMode                  = HttpMode.GET;
-		public static final String   httpProxyHost             = "";
+		public static final String   httpProxy                 = "";
         public static final Boolean  passBuildParameters       = false;
         public static final String   validResponseCodes        = "100:399";
         public static final String   validResponseContent      = "";

--- a/src/main/java/jenkins/plugins/http_request/HttpRequestExecution.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestExecution.java
@@ -70,7 +70,7 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 	private final String url;
 	private final HttpMode httpMode;
 	private final boolean ignoreSslErrors;
-	private final HttpHost httpProxyHost;
+	private final HttpHost httpProxy;
 
 	private final String body;
 	private final List<HttpRequestNameValuePair> headers;
@@ -99,7 +99,7 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 
 			return new HttpRequestExecution(
 					url, http.getHttpMode(), http.getIgnoreSslErrors(),
-					http.getHttpProxyHost(), body, headers, http.getTimeout(),
+					http.getHttpProxy(), body, headers, http.getTimeout(),
 					http.getAuthentication(),
 
 					http.getValidResponseCodes(), http.getValidResponseContent(),
@@ -119,7 +119,7 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 		Item project = execution.getProject();
 		return new HttpRequestExecution(
 				step.getUrl(), step.getHttpMode(), step.isIgnoreSslErrors(),
-				step.getHttpProxyHost(), step.getRequestBody(), headers, step.getTimeout(),
+				step.getHttpProxy(), step.getRequestBody(), headers, step.getTimeout(),
 				step.getAuthentication(),
 
 				step.getValidResponseCodes(), step.getValidResponseContent(),
@@ -130,7 +130,7 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 
 	private HttpRequestExecution(
 			String url, HttpMode httpMode, boolean ignoreSslErrors,
-			String httpProxyHost, String body, List<HttpRequestNameValuePair> headers, Integer timeout,
+			String httpProxy, String body, List<HttpRequestNameValuePair> headers, Integer timeout,
 			String authentication,
 
 			String validResponseCodes, String validResponseContent,
@@ -142,7 +142,7 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 		this.url = url;
 		this.httpMode = httpMode;
 		this.ignoreSslErrors = ignoreSslErrors;
-		this.httpProxyHost = StringUtils.isNotBlank(httpProxyHost) ? HttpHost.create(httpProxyHost) : null;
+		this.httpProxy = StringUtils.isNotBlank(httpProxy) ? HttpHost.create(httpProxy) : null;
 
 		this.body = body;
 		this.headers = headers;
@@ -218,8 +218,8 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 		try {
 			HttpClientBuilder clientBuilder = HttpClientBuilder.create().useSystemProperties();
 			configureTimeoutAndSsl(clientBuilder);
-			if (this.httpProxyHost != null) {
-				clientBuilder.setProxy(this.httpProxyHost);
+			if (this.httpProxy != null) {
+				clientBuilder.setProxy(this.httpProxy);
 			}
 
 			HttpClientUtil clientUtil = new HttpClientUtil();

--- a/src/main/java/jenkins/plugins/http_request/HttpRequestExecution.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestExecution.java
@@ -23,6 +23,8 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509ExtendedTrustManager;
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpRequestBase;
@@ -68,6 +70,7 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 	private final String url;
 	private final HttpMode httpMode;
 	private final boolean ignoreSslErrors;
+	private final HttpHost httpProxyHost;
 
 	private final String body;
 	private final List<HttpRequestNameValuePair> headers;
@@ -96,7 +99,7 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 
 			return new HttpRequestExecution(
 					url, http.getHttpMode(), http.getIgnoreSslErrors(),
-					body, headers, http.getTimeout(),
+					http.getHttpProxyHost(), body, headers, http.getTimeout(),
 					http.getAuthentication(),
 
 					http.getValidResponseCodes(), http.getValidResponseContent(),
@@ -116,7 +119,7 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 		Item project = execution.getProject();
 		return new HttpRequestExecution(
 				step.getUrl(), step.getHttpMode(), step.isIgnoreSslErrors(),
-				step.getRequestBody(), headers, step.getTimeout(),
+				step.getHttpProxyHost(), step.getRequestBody(), headers, step.getTimeout(),
 				step.getAuthentication(),
 
 				step.getValidResponseCodes(), step.getValidResponseContent(),
@@ -127,7 +130,7 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 
 	private HttpRequestExecution(
 			String url, HttpMode httpMode, boolean ignoreSslErrors,
-			String body, List<HttpRequestNameValuePair> headers, Integer timeout,
+			String httpProxyHost, String body, List<HttpRequestNameValuePair> headers, Integer timeout,
 			String authentication,
 
 			String validResponseCodes, String validResponseContent,
@@ -139,6 +142,7 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 		this.url = url;
 		this.httpMode = httpMode;
 		this.ignoreSslErrors = ignoreSslErrors;
+		this.httpProxyHost = StringUtils.isNotBlank(httpProxyHost) ? HttpHost.create(httpProxyHost) : null;
 
 		this.body = body;
 		this.headers = headers;
@@ -214,6 +218,9 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 		try {
 			HttpClientBuilder clientBuilder = HttpClientBuilder.create().useSystemProperties();
 			configureTimeoutAndSsl(clientBuilder);
+			if (this.httpProxyHost != null) {
+				clientBuilder.setProxy(this.httpProxyHost);
+			}
 
 			HttpClientUtil clientUtil = new HttpClientUtil();
 			HttpRequestBase httpRequestBase = clientUtil.createRequestBase(new RequestAction(new URL(url), httpMode, body, null, headers));

--- a/src/main/java/jenkins/plugins/http_request/HttpRequestStep.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestStep.java
@@ -36,6 +36,7 @@ public final class HttpRequestStep extends AbstractStepImpl {
     private @Nonnull String url;
 	private boolean ignoreSslErrors = DescriptorImpl.ignoreSslErrors;
 	private HttpMode httpMode                 = DescriptorImpl.httpMode;
+    private String httpProxyHost              = DescriptorImpl.httpProxyHost;
     private String validResponseCodes         = DescriptorImpl.validResponseCodes;
     private String validResponseContent       = DescriptorImpl.validResponseContent;
     private MimeType acceptType               = DescriptorImpl.acceptType;
@@ -73,6 +74,15 @@ public final class HttpRequestStep extends AbstractStepImpl {
 
     public HttpMode getHttpMode() {
         return httpMode;
+    }
+   
+    @DataBoundSetter
+    public void setHttpProxyHost(String httpProxyHost) {
+        this.httpProxyHost = httpProxyHost;
+    }
+
+    public String getHttpProxyHost() {
+        return httpProxyHost;
     }
 
     @DataBoundSetter
@@ -203,6 +213,7 @@ public final class HttpRequestStep extends AbstractStepImpl {
     public static final class DescriptorImpl extends AbstractStepDescriptorImpl {
         public static final boolean ignoreSslErrors = HttpRequest.DescriptorImpl.ignoreSslErrors;
         public static final HttpMode httpMode                  = HttpRequest.DescriptorImpl.httpMode;
+        public static final String   httpProxyHost             = HttpRequest.DescriptorImpl.httpProxyHost;
         public static final String   validResponseCodes        = HttpRequest.DescriptorImpl.validResponseCodes;
         public static final String   validResponseContent      = HttpRequest.DescriptorImpl.validResponseContent;
         public static final MimeType acceptType                = HttpRequest.DescriptorImpl.acceptType;

--- a/src/main/java/jenkins/plugins/http_request/HttpRequestStep.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestStep.java
@@ -36,7 +36,7 @@ public final class HttpRequestStep extends AbstractStepImpl {
     private @Nonnull String url;
 	private boolean ignoreSslErrors = DescriptorImpl.ignoreSslErrors;
 	private HttpMode httpMode                 = DescriptorImpl.httpMode;
-    private String httpProxyHost              = DescriptorImpl.httpProxyHost;
+    private String httpProxy                  = DescriptorImpl.httpProxy;
     private String validResponseCodes         = DescriptorImpl.validResponseCodes;
     private String validResponseContent       = DescriptorImpl.validResponseContent;
     private MimeType acceptType               = DescriptorImpl.acceptType;
@@ -77,12 +77,12 @@ public final class HttpRequestStep extends AbstractStepImpl {
     }
    
     @DataBoundSetter
-    public void setHttpProxyHost(String httpProxyHost) {
-        this.httpProxyHost = httpProxyHost;
+    public void setHttpProxy(String httpProxy) {
+        this.httpProxy = httpProxy;
     }
 
-    public String getHttpProxyHost() {
-        return httpProxyHost;
+    public String getHttpProxy() {
+        return httpProxy;
     }
 
     @DataBoundSetter
@@ -213,7 +213,7 @@ public final class HttpRequestStep extends AbstractStepImpl {
     public static final class DescriptorImpl extends AbstractStepDescriptorImpl {
         public static final boolean ignoreSslErrors = HttpRequest.DescriptorImpl.ignoreSslErrors;
         public static final HttpMode httpMode                  = HttpRequest.DescriptorImpl.httpMode;
-        public static final String   httpProxyHost             = HttpRequest.DescriptorImpl.httpProxyHost;
+        public static final String   httpProxy                 = HttpRequest.DescriptorImpl.httpProxy;
         public static final String   validResponseCodes        = HttpRequest.DescriptorImpl.validResponseCodes;
         public static final String   validResponseContent      = HttpRequest.DescriptorImpl.validResponseContent;
         public static final MimeType acceptType                = HttpRequest.DescriptorImpl.acceptType;

--- a/src/main/resources/jenkins/plugins/http_request/HttpRequest/config.jelly
+++ b/src/main/resources/jenkins/plugins/http_request/HttpRequest/config.jelly
@@ -9,7 +9,7 @@
 	<f:entry field="ignoreSslErrors" title="Ignore Ssl errors?" help="/plugin/http_request/help-ignoreSslErrors.html">
 		<f:booleanRadio />
 	</f:entry>
-	<f:entry field="httpProxyHost" title="Http Proxy Host" help="/plugin/http_request/help-httpProxy.html">
+	<f:entry field="httpProxy" title="Http Proxy" help="/plugin/http_request/help-httpProxy.html">
 		<f:textbox />
 	</f:entry>
 

--- a/src/main/resources/jenkins/plugins/http_request/HttpRequest/config.jelly
+++ b/src/main/resources/jenkins/plugins/http_request/HttpRequest/config.jelly
@@ -9,6 +9,9 @@
 	<f:entry field="ignoreSslErrors" title="Ignore Ssl errors?" help="/plugin/http_request/help-ignoreSslErrors.html">
 		<f:booleanRadio />
 	</f:entry>
+	<f:entry field="httpProxyHost" title="Http Proxy Host" help="/plugin/http_request/help-httpProxy.html">
+		<f:textbox />
+	</f:entry>
 
     <f:advanced>
         <f:section title="Authorization">

--- a/src/main/resources/jenkins/plugins/http_request/HttpRequestStep/config.jelly
+++ b/src/main/resources/jenkins/plugins/http_request/HttpRequestStep/config.jelly
@@ -11,7 +11,7 @@
 	</f:entry>
 
     <f:advanced>
-    	<f:entry field="httpProxyHost" title="Http Proxy Host" help="/plugin/http_request/help-httpProxy.html">
+    	<f:entry field="httpProxy" title="Http Proxy" help="/plugin/http_request/help-httpProxy.html">
     		<f:textbox />
     	</f:entry>
         <f:entry field="validResponseCodes" title="Response codes expected" help="/plugin/http_request/help-validResponseCodes.html">

--- a/src/main/resources/jenkins/plugins/http_request/HttpRequestStep/config.jelly
+++ b/src/main/resources/jenkins/plugins/http_request/HttpRequestStep/config.jelly
@@ -11,6 +11,9 @@
 	</f:entry>
 
     <f:advanced>
+    	<f:entry field="httpProxyHost" title="Http Proxy Host" help="/plugin/http_request/help-httpProxy.html">
+    		<f:textbox />
+    	</f:entry>
         <f:entry field="validResponseCodes" title="Response codes expected" help="/plugin/http_request/help-validResponseCodes.html">
             <f:textbox default="${descriptor.validResponseCodes}"/>
         </f:entry>

--- a/src/main/webapp/help-httpProxy.html
+++ b/src/main/webapp/help-httpProxy.html
@@ -1,0 +1,3 @@
+<div>
+    Use a proxy to process the HTTP request. Example : http://mycorpproxy:80
+</div>


### PR DESCRIPTION
Requested in #28 
Http proxy can now be passed as an argument in pipelines steps and classic job steps

Doc should be updated on https://jenkins.io/doc/pipeline/steps/http_request/#httprequest-perform-an-http-request-and-return-a-response-object