### PR TITLE
Plugin facelift (parent POM, HttpClient API plugin, etc.)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ THE SOFTWARE.
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>2.16</version>
+		<version>2.36</version>
 	</parent>
 
 	<artifactId>http_request</artifactId>
@@ -50,7 +50,8 @@ THE SOFTWARE.
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<jenkins.version>1.609.3</jenkins.version>
+		<jenkins.version>1.625.3</jenkins.version>
+		<java.level>7</java.level>
 		<workflow.version>1.10</workflow.version>
 	</properties>
 
@@ -74,7 +75,6 @@ THE SOFTWARE.
 				<groupId>org.jenkins-ci.tools</groupId>
 				<artifactId>maven-hpi-plugin</artifactId>
 				<configuration>
-					<pluginFirstClassLoader>true</pluginFirstClassLoader>
 					<compatibleSinceVersion>1.8.17</compatibleSinceVersion>
 				</configuration>
 			</plugin>
@@ -88,24 +88,14 @@ THE SOFTWARE.
 					</compilerArgs>
 				</configuration>
 			</plugin>
-			<plugin>
-				<artifactId>maven-enforcer-plugin</artifactId>
-				<configuration>
-					<rules>
-						<requireJavaVersion>
-							<version>[1.7,1.8)</version>
-						</requireJavaVersion>
-					</rules>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpclient</artifactId>
-			<version>4.5.3</version>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>apache-httpcomponents-client-4-api</artifactId>
+			<version>4.5.3-2.0</version>
 		</dependency>
 
 		<dependency>
@@ -137,13 +127,6 @@ THE SOFTWARE.
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-aggregator</artifactId>
 			<version>${workflow.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.eclipse.jetty</groupId>
-			<artifactId>jetty-servlets</artifactId>
-			<version>9.2.21.v20170120</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
I was trying to reproduce the Guava issue reported by @martinda for Maven plugin 3.0.0-rc1 (see https://github.com/jenkinsci/maven-plugin/pull/102). I failed to do so, but did some facelift work while I was around.

- [x] Update Core dependency to 1.625.3. The plugin would **NOT** work reliably on 1.609.3 with JDK6 anyway, because `java.level` defaults to Java 7
- [x] Update to the newest Parent POM
- [x] Use [Apache HttpComponents Client API 4.x plugin](https://plugins.jenkins.io/apache-httpcomponents-client-4-api) instead of the direct dependency
- [x] Disable the `pluginFirstClassloader`, there is no bundled JARs left anyway
- [x] Jetty Servlets dep is not required anymore, new JTH includes 9.4.x

@reviewbybees @martinda @janario