### PR TITLE
Support to POST application/xml

### DIFF
--- a/src/main/java/jenkins/plugins/http_request/MimeType.java
+++ b/src/main/java/jenkins/plugins/http_request/MimeType.java
@@ -14,7 +14,7 @@ public enum MimeType {
     TEXT_PLAIN(ContentType.TEXT_PLAIN),
     APPLICATION_FORM(ContentType.APPLICATION_FORM_URLENCODED),
     APPLICATION_JSON(ContentType.create("application/json")),
-	APPLICATION_XML(ContentType.APPLICATION_XML),
+    APPLICATION_XML(ContentType.APPLICATION_XML),
     APPLICATION_JSON_UTF8(ContentType.APPLICATION_JSON),
     APPLICATION_TAR(ContentType.create("application/x-tar")),
     APPLICATION_ZIP(ContentType.create("application/zip")),

--- a/src/main/java/jenkins/plugins/http_request/MimeType.java
+++ b/src/main/java/jenkins/plugins/http_request/MimeType.java
@@ -14,6 +14,7 @@ public enum MimeType {
     TEXT_PLAIN(ContentType.TEXT_PLAIN),
     APPLICATION_FORM(ContentType.APPLICATION_FORM_URLENCODED),
     APPLICATION_JSON(ContentType.create("application/json")),
+	APPLICATION_XML(ContentType.APPLICATION_XML),
     APPLICATION_JSON_UTF8(ContentType.APPLICATION_JSON),
     APPLICATION_TAR(ContentType.create("application/x-tar")),
     APPLICATION_ZIP(ContentType.create("application/zip")),


### PR DESCRIPTION
Recently I was trying to push an XML over a POST http method.

Is it the most common? No, nowadays few need to send XML over a http POST rest service.

But I was trying to update a Jenkins Job using the rest API , so I need to push the config.xml as application/xml with Push. I tried a bunch of workarounds for this plugin so gave up and decide to implement some custom stuffs with Java Code (I did not want to depend of Curl or sort of).

I do love this plugin, I think this an opportunity of improve, I could replicate the same errors in ARC and Postman Chrome plugins, just need to set the content type to application/xml and that was it.

