### PR TITLE
Support file uploads

### DIFF
--- a/src/main/java/jenkins/plugins/http_request/HttpRequest.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequest.java
@@ -69,6 +69,8 @@ public class HttpRequest extends Builder {
     private Boolean quiet                     = DescriptorImpl.quiet;
     private String authentication             = DescriptorImpl.authentication;
     private String requestBody                = DescriptorImpl.requestBody;
+    private String uploadFile                 = DescriptorImpl.uploadFile;
+    private String multipartName              = DescriptorImpl.multipartName;
     private List<HttpRequestNameValuePair> customHeaders = DescriptorImpl.customHeaders;
 
 	@DataBoundConstructor
@@ -217,6 +219,24 @@ public class HttpRequest extends Builder {
 		this.customHeaders = customHeaders;
 	}
 
+	public String getUploadFile() {
+		return uploadFile;
+	}
+
+	@DataBoundSetter
+	public void setUploadFile(String uploadFile) {
+		this.uploadFile = uploadFile;
+	}
+
+	public String getMultipartName() {
+		return multipartName;
+	}
+
+	@DataBoundSetter
+	public void setMultipartName(String multipartName) {
+		this.multipartName = multipartName;
+	}
+
 	@Initializer(before = InitMilestone.PLUGINS_STARTED)
 	public static void xStreamCompatibility() {
 		Items.XSTREAM2.aliasField("logResponseBody", HttpRequest.class, "consoleLogResponseBody");
@@ -314,6 +334,27 @@ public class HttpRequest extends Builder {
 		return workspace.child(filePath);
 	}
 
+	FilePath resolveUploadFile(EnvVars envVars, AbstractBuild<?,?> build) {
+		if (uploadFile == null || uploadFile.trim().isEmpty()) {
+			return null;
+		}
+		String filePath = envVars.expand(uploadFile);
+		try {
+			FilePath workspace = build.getWorkspace();
+			if (workspace == null) {
+				throw new IllegalStateException("Could not find workspace to check existence of upload file: " + uploadFile +
+						". You should use it inside a 'node' block");
+			}
+			FilePath uploadFilePath = workspace.child(filePath);
+				if (!uploadFilePath.exists()) {
+					throw new IllegalStateException("Could not find upload file: " + uploadFile);
+				}
+			return uploadFilePath;
+		} catch (IOException | InterruptedException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
     @Override
     public boolean perform(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener)
     throws InterruptedException, IOException
@@ -346,6 +387,8 @@ public class HttpRequest extends Builder {
         public static final Boolean  quiet                     = false;
         public static final String   authentication            = "";
         public static final String   requestBody               = "";
+        public static final String   uploadFile                = "";
+        public static final String   multipartName             = "";
         public static final List <HttpRequestNameValuePair> customHeaders = Collections.<HttpRequestNameValuePair>emptyList();
 
         public DescriptorImpl() {

--- a/src/main/java/jenkins/plugins/http_request/HttpRequestExecution.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestExecution.java
@@ -1,5 +1,6 @@
 package jenkins.plugins.http_request;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -24,12 +25,19 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509ExtendedTrustManager;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.mime.HttpMultipartMode;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.apache.http.entity.mime.content.FileBody;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.protocol.BasicHttpContext;
@@ -75,6 +83,9 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 	private final String body;
 	private final List<HttpRequestNameValuePair> headers;
 
+	private final FilePath uploadFile;
+	private final String multipartName;
+
 	private final String validResponseCodes;
 	private final String validResponseContent;
 	private final FilePath outputFile;
@@ -95,12 +106,13 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 			List<HttpRequestNameValuePair> headers = http.resolveHeaders(envVars);
 
 			FilePath outputFile = http.resolveOutputFile(envVars, build);
+			FilePath uploadFile = http.resolveUploadFile(envVars, build);
 			Item project = build.getProject();
 
 			return new HttpRequestExecution(
 					url, http.getHttpMode(), http.getIgnoreSslErrors(),
 					http.getHttpProxy(), body, headers, http.getTimeout(),
-					http.getAuthentication(),
+					http.getAuthentication(), uploadFile, http.getMultipartName(),
 
 					http.getValidResponseCodes(), http.getValidResponseContent(),
 					http.getConsoleLogResponseBody(), outputFile,
@@ -116,11 +128,12 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 	static HttpRequestExecution from(HttpRequestStep step, TaskListener taskListener, Execution execution) {
 		List<HttpRequestNameValuePair> headers = step.resolveHeaders();
 		FilePath outputFile = execution.resolveOutputFile();
+		FilePath uploadFile = execution.resolveUploadFile();
 		Item project = execution.getProject();
 		return new HttpRequestExecution(
 				step.getUrl(), step.getHttpMode(), step.isIgnoreSslErrors(),
 				step.getHttpProxy(), step.getRequestBody(), headers, step.getTimeout(),
-				step.getAuthentication(),
+				step.getAuthentication(), uploadFile, step.getMultipartName(),
 
 				step.getValidResponseCodes(), step.getValidResponseContent(),
 				step.getConsoleLogResponseBody(), outputFile,
@@ -131,7 +144,7 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 	private HttpRequestExecution(
 			String url, HttpMode httpMode, boolean ignoreSslErrors,
 			String httpProxy, String body, List<HttpRequestNameValuePair> headers, Integer timeout,
-			String authentication,
+			String authentication, FilePath uploadFile, String multipartName,
 
 			String validResponseCodes, String validResponseContent,
 			Boolean consoleLogResponseBody, FilePath outputFile,
@@ -170,6 +183,9 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 		} else {
 			authenticator = null;
 		}
+
+		this.uploadFile = uploadFile;
+		this.multipartName = multipartName;
 
 		this.validResponseCodes = validResponseCodes;
 		this.validResponseContent = validResponseContent != null ? validResponseContent : "";
@@ -224,8 +240,30 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 
 			HttpClientUtil clientUtil = new HttpClientUtil();
 			HttpRequestBase httpRequestBase = clientUtil.createRequestBase(new RequestAction(new URL(url), httpMode, body, null, headers));
-			HttpContext context = new BasicHttpContext();
 
+			// set multipart/form-data entity for file upload
+			if (uploadFile != null && httpMode == HttpMode.POST) {
+				MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+				builder.setMode(HttpMultipartMode.BROWSER_COMPATIBLE);
+
+				ContentType contentType = ContentType.APPLICATION_OCTET_STREAM;
+				for (HttpRequestNameValuePair header: headers) {
+					if ("Content-type".equalsIgnoreCase(header.getName())) {
+						contentType = ContentType.parse(header.getValue());
+						break;
+					}
+				}
+
+				FileBody fileBody = new FileBody(new File(uploadFile.getRemote()), contentType);
+				builder.addPart(multipartName, fileBody);
+				HttpEntity multiPartEntity = builder.build();
+
+				((HttpEntityEnclosingRequestBase) httpRequestBase).setEntity(multiPartEntity);
+				httpRequestBase.setHeader(multiPartEntity.getContentType());
+				httpRequestBase.setHeader(multiPartEntity.getContentEncoding());
+			}
+
+			HttpContext context = new BasicHttpContext();
 			httpclient = auth(clientBuilder, httpRequestBase, context);
 
 			ResponseContentSupplier response = executeRequest(httpclient, clientUtil, httpRequestBase, context);

--- a/src/main/java/jenkins/plugins/http_request/HttpRequestStep.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestStep.java
@@ -46,6 +46,8 @@ public final class HttpRequestStep extends AbstractStepImpl {
     private Boolean quiet                     = DescriptorImpl.quiet;
     private String authentication             = DescriptorImpl.authentication;
     private String requestBody                = DescriptorImpl.requestBody;
+    private String uploadFile                 = DescriptorImpl.uploadFile;
+	private String multipartName              = DescriptorImpl.multipartName;
     private List<HttpRequestNameValuePair> customHeaders = DescriptorImpl.customHeaders;
 	private String outputFile = DescriptorImpl.outputFile;
 	private ResponseHandle responseHandle = DescriptorImpl.responseHandle;
@@ -76,7 +78,7 @@ public final class HttpRequestStep extends AbstractStepImpl {
     public HttpMode getHttpMode() {
         return httpMode;
     }
-   
+
     @DataBoundSetter
     public void setHttpProxy(String httpProxy) {
         this.httpProxy = httpProxy;
@@ -195,6 +197,24 @@ public final class HttpRequestStep extends AbstractStepImpl {
 		this.responseHandle = responseHandle;
 	}
 
+	public String getUploadFile() {
+		return uploadFile;
+	}
+
+	@DataBoundSetter
+	public void setUploadFile(String uploadFile) {
+		this.uploadFile = uploadFile;
+	}
+
+	public String getMultipartName() {
+		return multipartName;
+	}
+
+	@DataBoundSetter
+	public void setMultipartName(String multipartName) {
+		this.multipartName = multipartName;
+	}
+
 	@Override
     public DescriptorImpl getDescriptor() {
         return (DescriptorImpl) super.getDescriptor();
@@ -233,6 +253,8 @@ public final class HttpRequestStep extends AbstractStepImpl {
         public static final Boolean  quiet                     = HttpRequest.DescriptorImpl.quiet;
         public static final String   authentication            = HttpRequest.DescriptorImpl.authentication;
         public static final String   requestBody               = HttpRequest.DescriptorImpl.requestBody;
+        public static final String   uploadFile                = HttpRequest.DescriptorImpl.uploadFile;
+        public static final String   multipartName             = HttpRequest.DescriptorImpl.multipartName;
         public static final List <HttpRequestNameValuePair> customHeaders = Collections.<HttpRequestNameValuePair>emptyList();
         public static final String outputFile = "";
 		public static final ResponseHandle responseHandle = ResponseHandle.STRING;
@@ -321,6 +343,28 @@ public final class HttpRequestStep extends AbstractStepImpl {
 							". You should use it inside a 'node' block");
 				}
 				return workspace.child(outputFile);
+			} catch (IOException | InterruptedException e) {
+				throw new IllegalStateException(e);
+			}
+		}
+
+		FilePath resolveUploadFile() {
+			String uploadFile = step.getUploadFile();
+			if (uploadFile == null || uploadFile.trim().isEmpty()) {
+				return null;
+			}
+
+			try {
+				FilePath workspace = getContext().get(FilePath.class);
+				if (workspace == null) {
+					throw new IllegalStateException("Could not find workspace to check existence of upload file: " + uploadFile +
+							". You should use it inside a 'node' block");
+				}
+				FilePath uploadFilePath = workspace.child(uploadFile);
+				if (!uploadFilePath.exists()) {
+					throw new IllegalStateException("Could not find upload file: " + uploadFile);
+				}
+				return uploadFilePath;
 			} catch (IOException | InterruptedException e) {
 				throw new IllegalStateException(e);
 			}

--- a/src/main/resources/jenkins/plugins/http_request/HttpRequest/config.jelly
+++ b/src/main/resources/jenkins/plugins/http_request/HttpRequest/config.jelly
@@ -6,12 +6,12 @@
     <f:entry field="httpMode" title="HTTP mode" help="/plugin/http_request/help-httpMode.html">
         <f:select />
     </f:entry>
-	<f:entry field="ignoreSslErrors" title="Ignore Ssl errors?" help="/plugin/http_request/help-ignoreSslErrors.html">
-		<f:booleanRadio />
-	</f:entry>
-	<f:entry field="httpProxy" title="Http Proxy" help="/plugin/http_request/help-httpProxy.html">
-		<f:textbox />
-	</f:entry>
+    <f:entry field="ignoreSslErrors" title="Ignore Ssl errors?" help="/plugin/http_request/help-ignoreSslErrors.html">
+        <f:booleanRadio />
+    </f:entry>
+    <f:entry field="httpProxy" title="Http Proxy" help="/plugin/http_request/help-httpProxy.html">
+        <f:textbox />
+    </f:entry>
 
     <f:advanced>
         <f:section title="Authorization">
@@ -36,6 +36,14 @@
             </f:entry>
             <f:entry field="requestBody" title="Request body" help="/plugin/http_request/help-requestBody.html">
                 <f:textarea />
+            </f:entry>
+        </f:section>
+        <f:section title="File Upload ">
+            <f:entry field="uploadFile" title="Upload file path" help="/plugin/http_request/help-uploadFile.html">
+                <f:textbox />
+            </f:entry>
+            <f:entry field="multipartName" title="Multipart entity name" help="/plugin/http_request/help-multipartName.html">
+                <f:textbox />
             </f:entry>
         </f:section>
         <f:section title="Response">

--- a/src/main/resources/jenkins/plugins/http_request/HttpRequestStep/config.jelly
+++ b/src/main/resources/jenkins/plugins/http_request/HttpRequestStep/config.jelly
@@ -6,14 +6,14 @@
     <f:entry field="httpMode" title="HTTP mode" help="/plugin/http_request/help-httpMode.html">
         <f:select />
     </f:entry>
-	<f:entry field="ignoreSslErrors" title="Ignore Ssl errors?" help="/plugin/http_request/help-ignoreSslErrors.html">
-		<f:booleanRadio />
-	</f:entry>
+    <f:entry field="ignoreSslErrors" title="Ignore Ssl errors?" help="/plugin/http_request/help-ignoreSslErrors.html">
+        <f:booleanRadio />
+    </f:entry>
 
     <f:advanced>
-    	<f:entry field="httpProxy" title="Http Proxy" help="/plugin/http_request/help-httpProxy.html">
-    		<f:textbox />
-    	</f:entry>
+        <f:entry field="httpProxy" title="Http Proxy" help="/plugin/http_request/help-httpProxy.html">
+            <f:textbox />
+        </f:entry>
         <f:entry field="validResponseCodes" title="Response codes expected" help="/plugin/http_request/help-validResponseCodes.html">
             <f:textbox default="${descriptor.validResponseCodes}"/>
         </f:entry>
@@ -41,8 +41,14 @@
         <f:entry field="requestBody" title="Request body" help="/plugin/http_request/help-requestBody.html">
             <f:textarea />
         </f:entry>
+        <f:entry field="uploadFile" title="Upload file path" help="/plugin/http_request/help-uploadFile.html">
+            <f:textbox />
+        </f:entry>
+        <f:entry field="multipartName" title="Multipart entity name" help="/plugin/http_request/help-multipartName.html">
+            <f:textbox />
+        </f:entry>
         <f:entry field="responseHandle" title="Handle of response" help="/plugin/http_request/help-responseHandle.html">
-			<f:select />
+            <f:select />
         </f:entry>
         <f:entry field="authentication" title="Authenticate" help="/plugin/http_request/help-authentication.html">
             <f:select />

--- a/src/main/webapp/help-multipartName.html
+++ b/src/main/webapp/help-multipartName.html
@@ -1,0 +1,3 @@
+<div>
+    Multipart entity name used in the <i>Content-Disposition</i> header in conjunction with the upload file path.
+</div>

--- a/src/main/webapp/help-uploadFile.html
+++ b/src/main/webapp/help-uploadFile.html
@@ -1,0 +1,5 @@
+<div>
+    Path to the upload file, relative to build workspace or absolute path.</p>
+    Can be used to upload a file as <i>multipart/form-data</i> <b>POST</b> request.
+    The according content type should be set above, defaults to <i>application/octet-stream</i> otherwise.
+</div>

--- a/src/test/java/jenkins/plugins/http_request/HttpRequestRoundTripTest.java
+++ b/src/test/java/jenkins/plugins/http_request/HttpRequestRoundTripTest.java
@@ -89,12 +89,21 @@ public class HttpRequestRoundTripTest {
         configRoundTrip(before);
     }
 
+    @Test
+    public void configRoundtripGroup4() throws Exception {
+        before.setUploadFile("upload.txt");
+        configRoundTrip(before);
+        before.setMultipartName("filename");
+        configRoundTrip(before);
+    }
+
     private void configRoundTrip(HttpRequest before) throws Exception {
         HttpRequest after = j.configRoundtrip(before);
         j.assertEqualBeans(before, after, "httpMode,passBuildParameters");
         j.assertEqualBeans(before, after, "url");
         j.assertEqualBeans(before, after, "validResponseCodes,validResponseContent");
         j.assertEqualBeans(before, after, "acceptType,contentType");
+        j.assertEqualBeans(before, after, "uploadFile,multipartName");
         j.assertEqualBeans(before, after, "outputFile,timeout");
         j.assertEqualBeans(before, after, "consoleLogResponseBody");
         j.assertEqualBeans(before, after, "authentication");

--- a/src/test/java/jenkins/plugins/http_request/HttpRequestStepRoundTripTest.java
+++ b/src/test/java/jenkins/plugins/http_request/HttpRequestStepRoundTripTest.java
@@ -12,6 +12,7 @@ import jenkins.plugins.http_request.util.RequestAction;
 import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
 import org.junit.Rule;
 import org.junit.Test;
+
 import static org.junit.Assert.assertEquals;
 
 import org.jvnet.hudson.test.JenkinsRule;
@@ -80,6 +81,14 @@ public class HttpRequestStepRoundTripTest {
         configRoundTrip(before);
     }
 
+    @Test
+    public void configRoundtripGroup4() throws Exception {
+        before.setUploadFile("upload.txt");
+        configRoundTrip(before);
+        before.setMultipartName("filename");
+        configRoundTrip(before);
+    }
+
     private void configRoundTrip(HttpRequestStep before) throws Exception {
         HttpRequestStep after  = new StepConfigTester(j).configRoundTrip(before);
         j.assertEqualBeans(before, after, "httpMode");
@@ -88,6 +97,8 @@ public class HttpRequestStepRoundTripTest {
         j.assertEqualBeans(before, after, "validResponseContent");
         j.assertEqualBeans(before, after, "acceptType");
         j.assertEqualBeans(before, after, "contentType");
+        j.assertEqualBeans(before, after, "uploadFile");
+        j.assertEqualBeans(before, after, "multipartName");
         j.assertEqualBeans(before, after, "timeout");
         j.assertEqualBeans(before, after, "consoleLogResponseBody");
         j.assertEqualBeans(before, after, "authentication");

--- a/src/test/java/jenkins/plugins/http_request/HttpRequestTest.java
+++ b/src/test/java/jenkins/plugins/http_request/HttpRequestTest.java
@@ -1,5 +1,7 @@
 package jenkins.plugins.http_request;
 
+import static jenkins.plugins.http_request.Registers.registerFileUpload;
+
 import static jenkins.plugins.http_request.Registers.registerAcceptedTypeRequestChecker;
 import static jenkins.plugins.http_request.Registers.registerBasicAuth;
 import static jenkins.plugins.http_request.Registers.registerCheckBuildParameters;
@@ -16,6 +18,7 @@ import static jenkins.plugins.http_request.Registers.registerRequestChecker;
 import static jenkins.plugins.http_request.Registers.registerTimeout;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -27,7 +30,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.ProtocolVersion;
@@ -35,7 +37,9 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicHttpResponse;
 import org.eclipse.jetty.server.Request;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import hudson.model.Cause.UserIdCause;
 import hudson.model.FreeStyleBuild;
@@ -52,6 +56,9 @@ import jenkins.plugins.http_request.util.RequestAction;
  * @author Martin d'Anjou
  */
 public class HttpRequestTest extends HttpRequestTestBase {
+
+	@Rule
+    public TemporaryFolder folder = new TemporaryFolder();
 
 	@Test
 	public void simpleGetTest() throws Exception {
@@ -908,6 +915,34 @@ public class HttpRequestTest extends HttpRequestTestBase {
 			}
 		}
 		Assert.assertEquals(2, valuesFoundCounter);
+		respSupplier.close();
+	}
 
+	@Test
+	public void testFileUpload() throws Exception {
+		// Prepare the server
+		final File testFolder = folder.newFolder();
+		File uploadFile = File.createTempFile("upload", ".zip", testFolder);
+		String responseText = "File upload successful!";
+		registerFileUpload(testFolder, uploadFile, responseText);
+
+		// Prepare HttpRequest
+		HttpRequest httpRequest = new HttpRequest(baseURL() + "/uploadFile");
+		httpRequest.setHttpMode(HttpMode.POST);
+		httpRequest.setValidResponseCodes("201");
+		httpRequest.setConsoleLogResponseBody(true);
+		httpRequest.setUploadFile(uploadFile.getAbsolutePath());
+		httpRequest.setMultipartName("file-name");
+		httpRequest.setContentType(MimeType.APPLICATION_ZIP);
+		httpRequest.setAcceptType(MimeType.TEXT_PLAIN);
+
+		// Run build
+		FreeStyleProject project = this.j.createFreeStyleProject();
+		project.getBuildersList().add(httpRequest);
+		FreeStyleBuild build = project.scheduleBuild2(0).get();
+
+		// Check expectations
+		this.j.assertBuildStatusSuccess(build);
+		this.j.assertLogContains(responseText, build);
 	}
 }


### PR DESCRIPTION
- adds an option to upload a file as multipart/form-data POST request
- upload file can be set relative to build workspace or as absolute path
- according content type should be set, defaults to application/octet-stream otherwise
- multipart entity name is required in conjunction with the upload file path to be used in the Content-Disposition header