### PR TITLE
Change ResponseContentSupplier.java to be public to allow typed interaction with the result

### DIFF
--- a/src/main/java/jenkins/plugins/http_request/ResponseContentSupplier.java
+++ b/src/main/java/jenkins/plugins/http_request/ResponseContentSupplier.java
@@ -29,7 +29,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  *         <p>
  *         A container for the Http Response. The container is returned as is to the Pipeline. For the normal plugin, the container is consumed internally (since it cannot be returned).
  */
-class ResponseContentSupplier implements Serializable, AutoCloseable {
+public class ResponseContentSupplier implements Serializable, AutoCloseable {
 
 	private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
At the moment ResponseContentSupplier.java is package private which makes it hard to use it for typing response variables.