### PR TITLE
Fix 57318: Allow null or empty value for validResponseCodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,11 @@ in the Pipeline job configuration.
 ### Known limitations
 
 * If Jenkins is restarted before the HTTP response comes back, the build will fail.
+
+## Building
+
+The plugin can be built and tested locally using a Maven Docker container:
+
+```
+docker run -it --rm -v "$(pwd)":/usr/src/mymaven -w /usr/src/mymaven maven:3.3-jdk-8 mvn test
+```

--- a/src/main/java/jenkins/plugins/http_request/HttpRequest.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequest.java
@@ -465,6 +465,10 @@ public class HttpRequest extends Builder {
         public static List<Range<Integer>> parseToRange(String value) {
             List<Range<Integer>> validRanges = new ArrayList<Range<Integer>>();
 
+            if (Strings.isNullOrEmpty(value)) {
+                return validRanges;
+            }
+
             String[] codes = value.split(",");
             for (String code : codes) {
                 String[] fromTo = code.trim().split(":");

--- a/src/main/java/jenkins/plugins/http_request/HttpRequest.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequest.java
@@ -466,7 +466,7 @@ public class HttpRequest extends Builder {
             List<Range<Integer>> validRanges = new ArrayList<Range<Integer>>();
 
             if (Strings.isNullOrEmpty(value)) {
-                return validRanges;
+                value = HttpRequest.DescriptorImpl.validResponseCodes;
             }
 
             String[] codes = value.split(",");

--- a/src/main/resources/jenkins/plugins/http_request/HttpRequestStep/help.html
+++ b/src/main/resources/jenkins/plugins/http_request/HttpRequestStep/help.html
@@ -8,6 +8,7 @@
         println("Content: "+response.content)
         </pre>
         <p>If Jenkins restarts after the HTTP request is made, but before the HTTP response is received, the HTTP request fails.</p>
+        <p><tt>validResponseCodes</tt> is a comma-separated string of single values or <tt>from:to</tt> ranges. For example <tt>'200'</tt> to accept only <tt>200</tt> or <tt>'201,301:303'</tt> to accept <tt>201</tt> as well as the range from <tt>301</tt> to <tt>303</tt>.</p>
     </p>
     <p>
         The methods of the response object are:

--- a/src/test/java/jenkins/plugins/http_request/HttpRequestDescriptorImplTest.java
+++ b/src/test/java/jenkins/plugins/http_request/HttpRequestDescriptorImplTest.java
@@ -1,0 +1,30 @@
+package jenkins.plugins.http_request;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.google.common.collect.Range;
+
+import org.junit.Test;
+
+/**
+ * @author Martin Mosegaard Amdisen
+ */
+public class HttpRequestDescriptorImplTest {
+
+    @Test
+    public void parseToRangeShouldHandleEmptyString() {
+        String value = "";
+        List<Range<Integer>> ranges = HttpRequest.DescriptorImpl.parseToRange(value);
+        assertEquals(ranges, Collections.<Range<Integer>>emptyList());
+    }
+
+    @Test
+    public void parseToRangeShouldHandleNull() {
+        String value = null;
+        List<Range<Integer>> ranges = HttpRequest.DescriptorImpl.parseToRange(value);
+        assertEquals(ranges, Collections.<Range<Integer>>emptyList());
+    }
+}

--- a/src/test/java/jenkins/plugins/http_request/HttpRequestDescriptorImplTest.java
+++ b/src/test/java/jenkins/plugins/http_request/HttpRequestDescriptorImplTest.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.List;
 
 import com.google.common.collect.Range;
+import com.google.common.collect.Ranges;
 
 import org.junit.Test;
 
@@ -14,17 +15,19 @@ import org.junit.Test;
  */
 public class HttpRequestDescriptorImplTest {
 
+    private static final List<Range<Integer>> DEFAULT_VALID_RESPONSE_CODES_RANGE = Collections.singletonList(Ranges.closed(100, 399));
+
     @Test
     public void parseToRangeShouldHandleEmptyString() {
         String value = "";
         List<Range<Integer>> ranges = HttpRequest.DescriptorImpl.parseToRange(value);
-        assertEquals(ranges, Collections.<Range<Integer>>emptyList());
+        assertEquals(DEFAULT_VALID_RESPONSE_CODES_RANGE, ranges);
     }
 
     @Test
     public void parseToRangeShouldHandleNull() {
         String value = null;
         List<Range<Integer>> ranges = HttpRequest.DescriptorImpl.parseToRange(value);
-        assertEquals(ranges, Collections.<Range<Integer>>emptyList());
+        assertEquals(DEFAULT_VALID_RESPONSE_CODES_RANGE, ranges);
     }
 }


### PR DESCRIPTION
Fixes https://issues.jenkins-ci.org/browse/JENKINS-57318

Change `HttpRequest.DescriptorImpl.parseToRange` to accept a null or empty string value.

Also added brief documentation about the syntax for `validResponseCodes` and
updated README with basic build instructions used for verifying this change.