### PR TITLE
Allow to use PUT for uploadFile

### DIFF
--- a/src/main/java/jenkins/plugins/http_request/HttpRequestExecution.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestExecution.java
@@ -251,7 +251,7 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 			HttpRequestBase httpRequestBase = clientUtil.createRequestBase(new RequestAction(new URL(url), httpMode, body, null, headers));
 
 			// set multipart/form-data entity for file upload
-			if (uploadFile != null && httpMode == HttpMode.POST) {
+			if (uploadFile != null && (httpMode == HttpMode.POST || httpMode == HttpMode.PUT)) {
 				MultipartEntityBuilder builder = MultipartEntityBuilder.create();
 				builder.setMode(HttpMultipartMode.BROWSER_COMPATIBLE);
 


### PR DESCRIPTION
Some systems (for ex. Sonatype Nexus) require to use PUT for file uploading.