### PR TITLE
Upgrade minimum Jenkins & use Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@ THE SOFTWARE.
 		<java.level>8</java.level>
 		<workflow.version>1.10</workflow.version>
 		<hpi.compatibleSinceVersion>1.8.17</hpi.compatibleSinceVersion>
+		<forkCount>1C</forkCount>
 	</properties>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ THE SOFTWARE.
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>2.36</version>
+		<version>3.54</version>
 	</parent>
 
 	<artifactId>http_request</artifactId>
@@ -49,10 +49,10 @@ THE SOFTWARE.
 	</licenses>
 
 	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<jenkins.version>1.625.3</jenkins.version>
-		<java.level>7</java.level>
+		<jenkins.version>2.60.3</jenkins.version>
+		<java.level>8</java.level>
 		<workflow.version>1.10</workflow.version>
+		<hpi.compatibleSinceVersion>1.8.17</hpi.compatibleSinceVersion>
 	</properties>
 
 	<repositories>
@@ -72,17 +72,8 @@ THE SOFTWARE.
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.jenkins-ci.tools</groupId>
-				<artifactId>maven-hpi-plugin</artifactId>
-				<configuration>
-					<compatibleSinceVersion>1.8.17</compatibleSinceVersion>
-				</configuration>
-			</plugin>
-			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<encoding>${project.build.sourceEncoding}</encoding>
-					<showDeprecation>true</showDeprecation>
 					<compilerArgs>
 						<compilerArg>-Xlint:all,-serial,-processing</compilerArg>
 					</compilerArgs>
@@ -92,7 +83,7 @@ THE SOFTWARE.
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-					<argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
+					<argLine>@{argLine} -Dfile.encoding=${project.build.sourceEncoding}</argLine>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/main/java/jenkins/plugins/http_request/HttpRequestGlobalConfig.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestGlobalConfig.java
@@ -45,9 +45,7 @@ public class HttpRequestGlobalConfig extends GlobalConfiguration {
 
     @Override
     protected XmlFile getConfigFile() {
-        Jenkins j = Jenkins.getInstance();
-        if (j == null) return null;
-        File rootDir = j.getRootDir();
+        File rootDir = Jenkins.getInstance().getRootDir();
         File xmlFile = new File(rootDir, "jenkins.plugins.http_request.HttpRequest.xml");
         return new XmlFile(XSTREAM2, xmlFile);
     }

--- a/src/test/java/jenkins/plugins/http_request/HttpRequestTest.java
+++ b/src/test/java/jenkins/plugins/http_request/HttpRequestTest.java
@@ -45,7 +45,9 @@ import hudson.model.Cause.UserIdCause;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Result;
+import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
 
 import jenkins.plugins.http_request.auth.FormAuthentication;
@@ -203,6 +205,9 @@ public class HttpRequestTest extends HttpRequestTestBase {
 
 		// Run build
 		FreeStyleProject project = this.j.createFreeStyleProject();
+		project.addProperty(new ParametersDefinitionProperty(
+				new StringParameterDefinition("foo", "default")
+		));
 		project.getBuildersList().add(httpRequest);
 		FreeStyleBuild build = project.scheduleBuild2(0, new UserIdCause(), new ParametersAction(new StringParameterValue("foo", "value"))).get();
 
@@ -232,6 +237,9 @@ public class HttpRequestTest extends HttpRequestTestBase {
 
 		// Run build
 		FreeStyleProject project = this.j.createFreeStyleProject();
+		project.addProperty(new ParametersDefinitionProperty(
+				new StringParameterDefinition("Tag", "default")
+		));
 		project.getBuildersList().add(httpRequest);
 
 		FreeStyleBuild build = project.scheduleBuild2(0, new UserIdCause(), new ParametersAction(new StringParameterValue("Tag", "trunk"))).get();
@@ -665,6 +673,10 @@ public class HttpRequestTest extends HttpRequestTestBase {
 
 		// Run build
 		FreeStyleProject project = this.j.createFreeStyleProject();
+		project.addProperty(new ParametersDefinitionProperty(
+				new StringParameterDefinition("Tag", "default"),
+				new StringParameterDefinition("WORKSPACE", "default")
+		));
 		project.getBuildersList().add(httpRequest);
 
 		FreeStyleBuild build = project.scheduleBuild2(0, new UserIdCause(),


### PR DESCRIPTION
- upgrade parent pom (to receive new features & fixes)
- no need to set encoding explicitly (already set via parent pom)
- use Java 8 (Java 7 is end of life since quite a while)
- use Jenkins LTS 2.60.3 (one of the first versions that requires Java 8)
- use property to configure `compatibleSinceVersion` (provided by never version of maven-hpi-plugin)
- use special `@{...}` argLine syntax for late replacement also use value set in parent pom
- configure test projects with parameters (newer versions of Jenkins ignore unknown URL parameters)
- remove redundant null check (found by SpotBugs)