### PR TITLE
Upload without multipart/form-data wrapping

### DIFF
--- a/src/main/java/jenkins/plugins/http_request/HttpRequest.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequest.java
@@ -72,6 +72,7 @@ public class HttpRequest extends Builder {
     private String requestBody                = DescriptorImpl.requestBody;
     private String uploadFile                 = DescriptorImpl.uploadFile;
     private String multipartName              = DescriptorImpl.multipartName;
+    private Boolean wrapAsMultipart           = DescriptorImpl.wrapAsMultipart;
     private Boolean useSystemProperties       = DescriptorImpl.useSystemProperties;
     private List<HttpRequestNameValuePair> customHeaders = DescriptorImpl.customHeaders;
 
@@ -248,6 +249,15 @@ public class HttpRequest extends Builder {
 		this.multipartName = multipartName;
 	}
 
+	public Boolean getWrapAsMultipart() {
+		return wrapAsMultipart;
+	}
+
+	@DataBoundSetter
+	public void setWrapAsMultipart(Boolean wrapAsMultipart) {
+		this.wrapAsMultipart = wrapAsMultipart;
+	}
+
 	@Initializer(before = InitMilestone.PLUGINS_STARTED)
 	public static void xStreamCompatibility() {
 		Items.XSTREAM2.aliasField("logResponseBody", HttpRequest.class, "consoleLogResponseBody");
@@ -404,6 +414,7 @@ public class HttpRequest extends Builder {
         public static final String   requestBody               = "";
         public static final String   uploadFile                = "";
         public static final String   multipartName             = "";
+        public static final Boolean  wrapAsMultipart           = true;
         public static final Boolean  useSystemProperties       = false;
         public static final List <HttpRequestNameValuePair> customHeaders = Collections.emptyList();
 

--- a/src/main/java/jenkins/plugins/http_request/HttpRequestStep.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestStep.java
@@ -49,6 +49,7 @@ public final class HttpRequestStep extends AbstractStepImpl {
     private String requestBody                = DescriptorImpl.requestBody;
     private String uploadFile                 = DescriptorImpl.uploadFile;
     private String multipartName              = DescriptorImpl.multipartName;
+    private Boolean wrapAsMultipart           = DescriptorImpl.wrapAsMultipart;
     private Boolean useSystemProperties       = DescriptorImpl.useSystemProperties;
     private List<HttpRequestNameValuePair> customHeaders = DescriptorImpl.customHeaders;
 	private String outputFile = DescriptorImpl.outputFile;
@@ -226,6 +227,15 @@ public final class HttpRequestStep extends AbstractStepImpl {
 		this.multipartName = multipartName;
 	}
 
+	public Boolean getWrapAsMultipart() {
+		return wrapAsMultipart;
+	}
+
+	@DataBoundSetter
+	public void setWrapAsMultipart(Boolean wrapAsMultipart) {
+		this.wrapAsMultipart = wrapAsMultipart;
+	}
+
 	@Override
     public DescriptorImpl getDescriptor() {
         return (DescriptorImpl) super.getDescriptor();
@@ -266,6 +276,7 @@ public final class HttpRequestStep extends AbstractStepImpl {
         public static final String   requestBody               = HttpRequest.DescriptorImpl.requestBody;
         public static final String   uploadFile                = HttpRequest.DescriptorImpl.uploadFile;
         public static final String   multipartName             = HttpRequest.DescriptorImpl.multipartName;
+        public static final Boolean  wrapAsMultipart           = HttpRequest.DescriptorImpl.wrapAsMultipart;
         public static final Boolean  useSystemProperties       = HttpRequest.DescriptorImpl.useSystemProperties;
         public static final List <HttpRequestNameValuePair> customHeaders = Collections.emptyList();
         public static final String outputFile = "";

--- a/src/main/webapp/help-wrapAsMultipart.html
+++ b/src/main/webapp/help-wrapAsMultipart.html
@@ -1,0 +1,4 @@
+<div>
+	If set to false an upload file will be set directly as body of the request and will not be
+	wrapped	as <i>multipart/form-data</i>.
+</div>

--- a/src/test/java/jenkins/plugins/http_request/Registers.java
+++ b/src/test/java/jenkins/plugins/http_request/Registers.java
@@ -319,6 +319,26 @@ public class Registers {
 		});
 	}
 
+	static void registerUnwrappedPutFileUpload(final File uploadFile, final String responseText) {
+		registerHandler("/uploadFile/" + uploadFile.getName(), HttpMode.PUT, new SimpleHandler() {
+
+			private static final String MULTIPART_FORMDATA_TYPE = "multipart/form-data";
+
+			private boolean isMultipartRequest(ServletRequest request) {
+				return request.getContentType() != null && request.getContentType().startsWith(MULTIPART_FORMDATA_TYPE);
+			}
+
+			@Override
+			void doHandle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException {
+				assertEquals("PUT", request.getMethod());
+				assertFalse(isMultipartRequest(request));
+				assertEquals(uploadFile.length(), request.getContentLength());
+				assertEquals(MimeType.APPLICATION_ZIP.getValue(), request.getContentType());
+				body(response, HttpServletResponse.SC_CREATED, ContentType.TEXT_PLAIN, responseText);
+			}
+		});
+	}
+
 	private static void registerHandler(String target, HttpMode method, SimpleHandler handler) {
 		HttpRequestTestBase.registerHandler(target, method, handler);
 	}


### PR DESCRIPTION
Added the possibility to upload files directly via PUT and POST without wrapping the content as multipart/form-data.

The need comes from artifactory, which does not support it for its PUT endpoints: https://www.jfrog.com/jira/browse/RTFACT-6314