### PR TITLE
Provide an ability to specify proxy authentication

### DIFF
--- a/src/main/java/jenkins/plugins/http_request/HttpRequest.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequest.java
@@ -59,6 +59,7 @@ public class HttpRequest extends Builder {
 	private Boolean ignoreSslErrors = DescriptorImpl.ignoreSslErrors;
 	private HttpMode httpMode                 = DescriptorImpl.httpMode;
 	private String httpProxy                  = DescriptorImpl.httpProxy;
+	private String proxyAuthentication        = DescriptorImpl.proxyAuthentication;
     private Boolean passBuildParameters       = DescriptorImpl.passBuildParameters;
     private String validResponseCodes         = DescriptorImpl.validResponseCodes;
     private String validResponseContent       = DescriptorImpl.validResponseContent;
@@ -202,6 +203,15 @@ public class HttpRequest extends Builder {
 	@DataBoundSetter
 	public void setAuthentication(String authentication) {
 		this.authentication = authentication;
+	}
+
+	public String getProxyAuthentication() {
+		return proxyAuthentication;
+	}
+
+	@DataBoundSetter
+	public void setProxyAuthentication(String proxyAuthentication) {
+		this.proxyAuthentication = proxyAuthentication;
 	}
 
 	public String getRequestBody() {
@@ -405,6 +415,7 @@ public class HttpRequest extends Builder {
 		public static final boolean ignoreSslErrors = false;
 		public static final HttpMode httpMode                  = HttpMode.GET;
 		public static final String   httpProxy                 = "";
+		public static final String proxyAuthentication         = "";
         public static final Boolean  passBuildParameters       = false;
         public static final String   validResponseCodes        = "100:399";
         public static final String   validResponseContent      = "";
@@ -453,6 +464,19 @@ public class HttpRequest extends Builder {
 													  @QueryParameter String url) {
             return fillAuthenticationItems(project, url);
         }
+
+        public ListBoxModel doFillProxyAuthenticationItems(@AncestorInPath Item project,
+														   @QueryParameter String url) {
+			if (project == null || !project.hasPermission(Item.CONFIGURE)) {
+				return new StandardListBoxModel();
+			} else {
+				return new StandardListBoxModel()
+						.includeEmptyValue()
+						.includeAs(ACL.SYSTEM,
+								project, StandardUsernamePasswordCredentials.class,
+								URIRequirementBuilder.fromUri(url).build());
+			}
+		}
 
         public static ListBoxModel fillAuthenticationItems(Item project, String url) {
 			if (project == null || !project.hasPermission(Item.CONFIGURE)) {

--- a/src/main/java/jenkins/plugins/http_request/HttpRequestExecution.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestExecution.java
@@ -83,6 +83,7 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 	private final HttpMode httpMode;
 	private final boolean ignoreSslErrors;
 	private final HttpHost httpProxy;
+	private final StandardUsernamePasswordCredentials proxyCredentials;
 
 	private final String body;
 	private final List<HttpRequestNameValuePair> headers;
@@ -117,7 +118,8 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 
 			return new HttpRequestExecution(
 					url, http.getHttpMode(), http.getIgnoreSslErrors(),
-					http.getHttpProxy(), body, headers, http.getTimeout(),
+					http.getHttpProxy(), http.getProxyAuthentication(),
+					body, headers, http.getTimeout(),
 					uploadFile, http.getMultipartName(), http.getWrapAsMultipart(),
 					http.getAuthentication(), http.getUseSystemProperties(),
 
@@ -139,7 +141,8 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 		Item project = execution.getProject();
 		return new HttpRequestExecution(
 				step.getUrl(), step.getHttpMode(), step.isIgnoreSslErrors(),
-				step.getHttpProxy(), step.getRequestBody(), headers, step.getTimeout(),
+				step.getHttpProxy(), step.getProxyAuthentication(),
+				step.getRequestBody(), headers, step.getTimeout(),
 				uploadFile, step.getMultipartName(), step.isWrapAsMultipart(),
 				step.getAuthentication(), step.getUseSystemProperties(),
 
@@ -151,7 +154,8 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 
 	private HttpRequestExecution(
 			String url, HttpMode httpMode, boolean ignoreSslErrors,
-			String httpProxy, String body, List<HttpRequestNameValuePair> headers, Integer timeout,
+			String httpProxy, String proxyAuthentication, String body,
+			List<HttpRequestNameValuePair> headers, Integer timeout,
 			FilePath uploadFile, String multipartName, boolean wrapAsMultipart,
 			String authentication, boolean useSystemProperties,
 
@@ -164,7 +168,30 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 		this.url = url;
 		this.httpMode = httpMode;
 		this.ignoreSslErrors = ignoreSslErrors;
-		this.httpProxy = StringUtils.isNotBlank(httpProxy) ? HttpHost.create(httpProxy) : null;
+
+		if (StringUtils.isNotBlank(httpProxy)) {
+			this.httpProxy = HttpHost.create(httpProxy);
+			if (StringUtils.isNotBlank(proxyAuthentication)) {
+
+				StandardCredentials credential = CredentialsMatchers.firstOrNull(
+						CredentialsProvider.lookupCredentials(
+								StandardCredentials.class,
+								project, ACL.SYSTEM,
+								URIRequirementBuilder.fromUri(url).build()),
+						CredentialsMatchers.withId(proxyAuthentication));
+				if (credential instanceof StandardUsernamePasswordCredentials) {
+					this.proxyCredentials = (StandardUsernamePasswordCredentials) credential;
+				} else {
+					this.proxyCredentials = null;
+					throw new IllegalStateException("Proxy authentication '" + proxyAuthentication + "' doesn't exist anymore or is not a username/password credential type");
+				}
+			} else {
+				this.proxyCredentials = null;
+			}
+		} else {
+			this.httpProxy = null;
+			this.proxyCredentials = null;
+		}
 
 		this.body = body;
 		this.headers = headers;
@@ -331,6 +358,17 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 	private CloseableHttpClient auth(
 			HttpClientBuilder clientBuilder, HttpRequestBase httpRequestBase,
 			HttpContext context) throws IOException, InterruptedException {
+
+		if (proxyCredentials != null) {
+			logger().println("Using proxy authentication: " + proxyCredentials.getId());
+			if (authenticator instanceof CredentialBasicAuthentication) {
+				((CredentialBasicAuthentication) authenticator).addCredentials(httpProxy, proxyCredentials);
+			} else {
+				new CredentialBasicAuthentication((StandardUsernamePasswordCredentials) proxyCredentials)
+						.prepare(clientBuilder, context, httpProxy);
+			}
+		}
+
 		if (authenticator == null) {
 			return clientBuilder.build();
 		}

--- a/src/main/java/jenkins/plugins/http_request/HttpRequestStep.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestStep.java
@@ -38,6 +38,7 @@ public final class HttpRequestStep extends AbstractStepImpl {
 	private boolean ignoreSslErrors = DescriptorImpl.ignoreSslErrors;
 	private HttpMode httpMode                 = DescriptorImpl.httpMode;
     private String httpProxy                  = DescriptorImpl.httpProxy;
+    private String proxyAuthentication        = DescriptorImpl.proxyAuthentication;
     private String validResponseCodes         = DescriptorImpl.validResponseCodes;
     private String validResponseContent       = DescriptorImpl.validResponseContent;
     private MimeType acceptType               = DescriptorImpl.acceptType;
@@ -163,7 +164,16 @@ public final class HttpRequestStep extends AbstractStepImpl {
         return authentication;
     }
 
-    @DataBoundSetter
+	@DataBoundSetter
+	public void setProxyAuthentication(String proxyAuthentication) {
+		this.proxyAuthentication = proxyAuthentication;
+	}
+
+	public String getProxyAuthentication() {
+		return proxyAuthentication;
+	}
+
+	@DataBoundSetter
     public void setRequestBody(String requestBody) {
         this.requestBody = requestBody;
     }
@@ -265,6 +275,7 @@ public final class HttpRequestStep extends AbstractStepImpl {
         public static final boolean ignoreSslErrors = HttpRequest.DescriptorImpl.ignoreSslErrors;
         public static final HttpMode httpMode                  = HttpRequest.DescriptorImpl.httpMode;
         public static final String   httpProxy                 = HttpRequest.DescriptorImpl.httpProxy;
+        public static final String   proxyAuthentication       = HttpRequest.DescriptorImpl.proxyAuthentication;
         public static final String   validResponseCodes        = HttpRequest.DescriptorImpl.validResponseCodes;
         public static final String   validResponseContent      = HttpRequest.DescriptorImpl.validResponseContent;
         public static final MimeType acceptType                = HttpRequest.DescriptorImpl.acceptType;
@@ -321,7 +332,12 @@ public final class HttpRequestStep extends AbstractStepImpl {
             return HttpRequest.DescriptorImpl.fillAuthenticationItems(project, url);
         }
 
-        public FormValidation doCheckValidResponseCodes(@QueryParameter String value) {
+		public ListBoxModel doFillProxyAuthenticationItems(@AncestorInPath Item project,
+														   @QueryParameter String url) {
+			return HttpRequest.DescriptorImpl.fillAuthenticationItems(project, url);
+		}
+
+		public FormValidation doCheckValidResponseCodes(@QueryParameter String value) {
             return HttpRequest.DescriptorImpl.checkValidResponseCodes(value);
         }
 

--- a/src/main/java/jenkins/plugins/http_request/auth/BasicDigestAuthentication.java
+++ b/src/main/java/jenkins/plugins/http_request/auth/BasicDigestAuthentication.java
@@ -3,6 +3,7 @@ package jenkins.plugins.http_request.auth;
 import java.io.PrintStream;
 
 import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.utils.URIUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.protocol.HttpContext;
@@ -52,7 +53,8 @@ public class BasicDigestAuthentication extends AbstractDescribableImpl<BasicDige
 	@Override
 	public CloseableHttpClient authenticate(HttpClientBuilder clientBuilder, HttpContext context,
 											HttpRequestBase requestBase, PrintStream logger) {
-		return CredentialBasicAuthentication.auth(clientBuilder, context, requestBase, userName, password);
+		CredentialBasicAuthentication.auth(clientBuilder, context, URIUtils.extractHost(requestBase.getURI()), userName, password);
+		return clientBuilder.build();
 	}
 
     @Extension

--- a/src/main/resources/jenkins/plugins/http_request/HttpRequestStep/config.jelly
+++ b/src/main/resources/jenkins/plugins/http_request/HttpRequestStep/config.jelly
@@ -14,6 +14,9 @@
         <f:entry field="httpProxy" title="Http Proxy" help="/plugin/http_request/help-httpProxy.html">
             <f:textbox />
         </f:entry>
+        <f:entry field="proxyAuthentication" title="Proxy authenticate" help="/plugin/http_request/help-proxyAuthentication.html">
+            <f:select />
+        </f:entry>
         <f:entry field="validResponseCodes" title="Response codes expected" help="/plugin/http_request/help-validResponseCodes.html">
             <f:textbox default="${descriptor.validResponseCodes}"/>
         </f:entry>

--- a/src/main/webapp/help-proxyAuthentication.html
+++ b/src/main/webapp/help-proxyAuthentication.html
@@ -1,0 +1,4 @@
+<div>
+    Proxy authentication that will be used before this request - only applicable if Http Proxy is set.
+    Authentications are created in global configuration under a key name that is selected here.
+</div>

--- a/src/test/java/jenkins/plugins/http_request/HttpRequestTest.java
+++ b/src/test/java/jenkins/plugins/http_request/HttpRequestTest.java
@@ -985,4 +985,24 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		this.j.assertBuildStatusSuccess(build);
 		this.j.assertLogContains(responseText, build);
 	}
+
+	@Test
+	public void nonExistentProxyAuthFailsTheBuild() throws Exception {
+		// Prepare the server
+		registerBasicAuth();
+
+		// Prepare HttpRequest
+		HttpRequest httpRequest = new HttpRequest(baseURL() + "/basicAuth");
+		httpRequest.setHttpProxy("http://proxy.example.com:8888");
+		httpRequest.setProxyAuthentication("non-existent-key");
+
+		// Run build
+		FreeStyleProject project = this.j.createFreeStyleProject();
+		project.getBuildersList().add(httpRequest);
+		FreeStyleBuild build = project.scheduleBuild2(0).get();
+
+		// Check expectations
+		this.j.assertBuildStatus(Result.FAILURE, build);
+	}
+
 }


### PR DESCRIPTION
While the plugin allows specifying proxy server, it currently does not support authenticating proxies (i.e. where proxy requires a username/password).  This pull request adds this functionality.  Proxy authentication is specified from global Jenkins credentials.