### PR TITLE
Use GitHub as the source of documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@ THE SOFTWARE.
 		This plugin sends a http request to an url with some parameters.
 		See the release notes for changes and compatibility https://github.com/jenkinsci/http-request-plugin/releases
 	</description>
-	<url>https://wiki.jenkins.io/display/JENKINS/HTTP+Request+Plugin</url>
+	<url>https://github.com/jenkinsci/http-request-plugin</url>
 
 	<licenses>
 		<license>


### PR DESCRIPTION
This makes sure plugin docs are loaded from GitHub and not the read-only Jenkins Wiki.
See https://issues.jenkins-ci.org/browse/WEBSITE-637