### PR TITLE
Refresh plugin

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.2</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -27,11 +27,11 @@ THE SOFTWARE.
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>3.54</version>
+		<version>4.12</version>
 	</parent>
 
 	<artifactId>http_request</artifactId>
-	<version>1.8.27-SNAPSHOT</version>
+	<version>${revision}${changelist}</version>
 	<packaging>hpi</packaging>
 	<name>HTTP Request Plugin</name>
 	<description>
@@ -49,9 +49,11 @@ THE SOFTWARE.
 	</licenses>
 
 	<properties>
-		<jenkins.version>2.60.3</jenkins.version>
+		<revision>1.8.27</revision>
+		<changelist>-SNAPSHOT</changelist>
+		<gitHubRepo>jenkinsci/http-request-plugin</gitHubRepo>
+		<jenkins.version>2.204.6</jenkins.version>
 		<java.level>8</java.level>
-		<workflow.version>1.10</workflow.version>
 		<hpi.compatibleSinceVersion>1.8.17</hpi.compatibleSinceVersion>
 		<forkCount>1C</forkCount>
 	</properties>
@@ -90,27 +92,35 @@ THE SOFTWARE.
 		</plugins>
 	</build>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>io.jenkins.tools.bom</groupId>
+				<artifactId>bom-2.204.x</artifactId>
+				<version>16</version>
+				<scope>import</scope>
+				<type>pom</type>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>apache-httpcomponents-client-4-api</artifactId>
-			<version>4.5.3-2.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>credentials</artifactId>
-			<version>2.1.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>script-security</artifactId>
-			<version>1.17</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-step-api</artifactId>
-			<version>${workflow.version}</version>
 			<optional>true</optional>
 		</dependency>
 
@@ -118,23 +128,34 @@ THE SOFTWARE.
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-step-api</artifactId>
-			<version>${workflow.version}</version>
 			<classifier>tests</classifier>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
-			<artifactId>workflow-aggregator</artifactId>
-			<version>${workflow.version}</version>
+			<artifactId>workflow-basic-steps</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-cps</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-durable-task-step</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-job</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
 
 	<scm>
-		<connection>scm:git:ssh://github.com/jenkinsci/http-request-plugin.git</connection>
-		<developerConnection>scm:git:ssh://git@github.com/jenkinsci/http-request-plugin.git</developerConnection>
-		<url>https://github.com/jenkinsci/http-request-plugin</url>
-		<tag>HEAD</tag>
+		<connection>scm:git:ssh://github.com/${gitHubRepo}.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/${gitHubRepo}.git</developerConnection>
+		<url>https://github.com/${gitHubRepo}</url>
+		<tag>${scmTag}</tag>
 	</scm>
 	<developers>
 		<developer>

--- a/src/main/java/jenkins/plugins/http_request/HttpRequest.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequest.java
@@ -38,6 +38,7 @@ import hudson.model.BuildListener;
 import hudson.model.Item;
 import hudson.model.Items;
 import hudson.model.TaskListener;
+import hudson.remoting.VirtualChannel;
 import hudson.security.ACL;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
@@ -395,7 +396,11 @@ public class HttpRequest extends Builder {
 
 		HttpRequestExecution exec = HttpRequestExecution.from(this, envVars, build,
 				this.getQuiet() ? TaskListener.NULL : listener);
-		launcher.getChannel().call(exec);
+		VirtualChannel channel = launcher.getChannel();
+		if (channel == null) {
+			throw new IllegalStateException("Launcher doesn't support remoting but it is required");
+		}
+		channel.call(exec);
 
         return true;
     }

--- a/src/main/java/jenkins/plugins/http_request/HttpRequestStep.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestStep.java
@@ -24,6 +24,7 @@ import hudson.Launcher;
 import hudson.model.Item;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.remoting.VirtualChannel;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 
@@ -345,7 +346,11 @@ public final class HttpRequestStep extends AbstractStepImpl {
 
 			Launcher launcher = getContext().get(Launcher.class);
 			if (launcher != null) {
-				return launcher.getChannel().call(exec);
+				VirtualChannel channel = launcher.getChannel();
+				if (channel == null) {
+					throw new IllegalStateException("Launcher doesn't support remoting but it is required");
+				}
+				return channel.call(exec);
 			}
 
 			return exec.call();

--- a/src/test/java/jenkins/plugins/http_request/Registers.java
+++ b/src/test/java/jenkins/plugins/http_request/Registers.java
@@ -22,9 +22,8 @@ import javax.servlet.http.Part;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpHeaders;
 import org.apache.http.entity.ContentType;
+import org.eclipse.jetty.http.MultiPartFormInputStream;
 import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.util.MultiException;
-import org.eclipse.jetty.util.MultiPartInputStreamParser;
 
 import com.google.common.collect.Iterables;
 
@@ -281,7 +280,7 @@ public class Registers {
 			private static final String MULTIPART_FORMDATA_TYPE = "multipart/form-data";
 
 			private void enableMultipartSupport(HttpServletRequest request, MultipartConfigElement multipartConfig) {
-				request.setAttribute(Request.__MULTIPART_CONFIG_ELEMENT, multipartConfig);
+				request.setAttribute(Request.MULTIPART_CONFIG_ELEMENT, multipartConfig);
 			}
 
 			private boolean isMultipartRequest(ServletRequest request) {
@@ -305,14 +304,10 @@ public class Registers {
 
 					body(response, HttpServletResponse.SC_CREATED, ContentType.TEXT_PLAIN, responseText);
 				} finally {
-					MultiPartInputStreamParser multipartInputStream = (MultiPartInputStreamParser) request
-							.getAttribute(Request.__MULTIPART_INPUT_STREAM);
+					String MULTIPART = "org.eclipse.jetty.servlet.MultiPartFile.multiPartInputStream";
+					MultiPartFormInputStream multipartInputStream = (MultiPartFormInputStream) request.getAttribute(MULTIPART);
 					if (multipartInputStream != null) {
-						try {
-							multipartInputStream.deleteParts();
-						} catch (MultiException e) {
-							// ignore
-						}
+						multipartInputStream.deleteParts();
 					}
 				}
 			}


### PR DESCRIPTION
In preparation for fixing https://issues.jenkins-ci.org/browse/JENKINS-64054 this plugin needs recent parent pom and core version so dependency versions aren't a pain.

I've added incrementals and bom to make testing a pre-release simple

2.204.x is the current conservative baseline, although official docs are recommending slightly newer (https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/)

@janario

