### PR TITLE
honor maskValue flag for Authorization header

### DIFF
--- a/src/main/java/jenkins/plugins/http_request/HttpRequest.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequest.java
@@ -332,8 +332,7 @@ public class HttpRequest extends Builder {
 		for (HttpRequestNameValuePair header : customHeaders) {
 			String headerName = envVars.expand(header.getName());
 			String headerValue = envVars.expand(header.getValue());
-			boolean maskValue = headerName.equalsIgnoreCase(HttpHeaders.AUTHORIZATION) ||
-					header.getMaskValue();
+			boolean maskValue = header.getMaskValue();
 
 			headers.add(new HttpRequestNameValuePair(headerName, headerValue, maskValue));
 		}

--- a/src/main/java/jenkins/plugins/http_request/HttpRequestStep.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestStep.java
@@ -253,8 +253,7 @@ public final class HttpRequestStep extends AbstractStepImpl {
 		for (HttpRequestNameValuePair header : customHeaders) {
 			String headerName = header.getName();
 			String headerValue = header.getValue();
-			boolean maskValue = headerName.equalsIgnoreCase(HttpHeaders.AUTHORIZATION) ||
-					header.getMaskValue();
+			boolean maskValue = header.getMaskValue();
 
 			headers.add(new HttpRequestNameValuePair(headerName, headerValue, maskValue));
 		}

--- a/src/main/java/jenkins/plugins/http_request/util/HttpRequestNameValuePair.java
+++ b/src/main/java/jenkins/plugins/http_request/util/HttpRequestNameValuePair.java
@@ -3,6 +3,7 @@ package jenkins.plugins.http_request.util;
 import java.io.Serializable;
 
 import org.apache.http.NameValuePair;
+import org.apache.http.HttpHeaders;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
@@ -30,7 +31,11 @@ public class HttpRequestNameValuePair extends AbstractDescribableImpl<HttpReques
     }
 
     public HttpRequestNameValuePair(String name, String value) {
-        this(name, value, false);
+        if (name.equalsIgnoreCase(HttpHeaders.AUTHORIZATION)) {
+            this(name, value, true);
+        } else {
+            this(name, value, false);
+        }
     }
 
     public String getName() {


### PR DESCRIPTION
Hi @oleg-nenashev ,

I was trying to debug a request in Jenkins, set `maskValue: false` for Authorization header and found it didn't honor this flag.
I understand this change was by https://github.com/jenkinsci/http-request-plugin/pull/22 and for case some security concerns (https://issues.jenkins.io/browse/JENKINS-39744).

I would like to propose an enhancement here which both respects `maskValue`flag and also masks Authorization header by default.

So I set default `maskValue = true` in HttpRequestNameValuePair.java constructor. In this case, when user passes `maskValue: false` in Authorization header, it can be honored correctly.

Please correct me if I missed something or you have further security concerns about this change.

Thanks for your great job done here!

Best regards,
Kevin