### PR TITLE
Store response headers in TreeMap with case insensitive comparator

### DIFF
--- a/src/main/java/jenkins/plugins/http_request/ResponseContentSupplier.java
+++ b/src/main/java/jenkins/plugins/http_request/ResponseContentSupplier.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -37,7 +38,7 @@ public class ResponseContentSupplier implements Serializable, AutoCloseable {
 	private static final long serialVersionUID = 1L;
 
 	private int status;
-	private Map<String, List<String>> headers = new HashMap<>();
+	private Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 	private String charset;
 
 	private ResponseHandle responseHandle;

--- a/src/test/java/jenkins/plugins/http_request/HttpRequestTest.java
+++ b/src/test/java/jenkins/plugins/http_request/HttpRequestTest.java
@@ -931,6 +931,22 @@ public class HttpRequestTest extends HttpRequestTestBase {
 	}
 
 	@Test
+	public void responseContentSupplierHeadersCaseInsensitivity() throws Exception {
+		// Prepare test context
+		HttpResponse response = new BasicHttpResponse(new ProtocolVersion("HTTP", 1, 1), 200, "OK");
+		response.setEntity(new StringEntity("TEST"));
+		response.setHeader("Server", "Jenkins");
+		// Run test
+		ResponseContentSupplier respSupplier = new ResponseContentSupplier(ResponseHandle.STRING, response);
+		// Check expectations
+		Assert.assertEquals(1, respSupplier.getHeaders().size());
+		Assert.assertTrue(respSupplier.getHeaders().containsKey("Server"));
+		Assert.assertTrue(respSupplier.getHeaders().containsKey("SERVER"));
+		Assert.assertTrue(respSupplier.getHeaders().containsKey("server"));
+		respSupplier.close();
+	}
+
+	@Test
 	public void testFileUpload() throws Exception {
 		// Prepare the server
 		final File testFolder = folder.newFolder();


### PR DESCRIPTION
According to RFC 2616, message headers filed names are case insensitive.
Response headers should be stored in a container which support case insensitive comparison.