### PR TITLE
Migrate from `com.google.common.collect.Range` and `com.google.common.collect.Ranges` to `java.util.stream.IntStream`

### DIFF
--- a/src/main/java/jenkins/plugins/http_request/HttpRequest.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequest.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.IntStream;
 
 import javax.annotation.Nonnull;
 
@@ -23,8 +24,6 @@ import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import com.google.common.base.Strings;
-import com.google.common.collect.Range;
-import com.google.common.collect.Ranges;
 
 import hudson.EnvVars;
 import hudson.Extension;
@@ -517,8 +516,8 @@ public class HttpRequest extends Builder {
             return items;
         }
 
-        public static List<Range<Integer>> parseToRange(String value) {
-            List<Range<Integer>> validRanges = new ArrayList<>();
+        public static List<IntStream> parseToRange(String value) {
+            List<IntStream> validRanges = new ArrayList<>();
 
             if (Strings.isNullOrEmpty(value)) {
                 value = HttpRequest.DescriptorImpl.validResponseCodes;
@@ -546,7 +545,7 @@ public class HttpRequest extends Builder {
                 }
 
                 checkArgument(from <= to, "Interval %s should be FROM less than TO", code);
-                validRanges.add(Ranges.closed(from, to));
+                validRanges.add(IntStream.rangeClosed(from, to));
             }
 
             return validRanges;

--- a/src/main/java/jenkins/plugins/http_request/HttpRequestExecution.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestExecution.java
@@ -18,6 +18,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
@@ -50,7 +51,6 @@ import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
-import com.google.common.collect.Range;
 import com.google.common.io.ByteStreams;
 
 import hudson.AbortException;
@@ -404,14 +404,14 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 	}
 
 	private void responseCodeIsValid(ResponseContentSupplier response) throws AbortException {
-		List<Range<Integer>> ranges = DescriptorImpl.parseToRange(validResponseCodes);
-		for (Range<Integer> range : ranges) {
-			if (range.contains(response.getStatus())) {
+		List<IntStream> ranges = DescriptorImpl.parseToRange(validResponseCodes);
+		for (IntStream range : ranges) {
+			if (range.anyMatch(status -> status == response.getStatus())) {
 				logger().println("Success code from " + range);
 				return;
 			}
 		}
-		throw new AbortException("Fail: the returned code " + response.getStatus() + " is not in the accepted range: " + ranges);
+		throw new AbortException("Fail: the returned code " + response.getStatus() + " is not in the accepted range: " + validResponseCodes);
 	}
 
 	private void processResponse(ResponseContentSupplier response) throws IOException, InterruptedException {

--- a/src/test/java/jenkins/plugins/http_request/HttpRequestDescriptorImplTest.java
+++ b/src/test/java/jenkins/plugins/http_request/HttpRequestDescriptorImplTest.java
@@ -2,11 +2,9 @@ package jenkins.plugins.http_request;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Collections;
 import java.util.List;
-
-import com.google.common.collect.Range;
-import com.google.common.collect.Ranges;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.junit.Test;
 
@@ -15,19 +13,25 @@ import org.junit.Test;
  */
 public class HttpRequestDescriptorImplTest {
 
-    private static final List<Range<Integer>> DEFAULT_VALID_RESPONSE_CODES_RANGE = Collections.singletonList(Ranges.closed(100, 399));
+    private static final List<Integer> DEFAULT_VALID_RESPONSE_CODES_RANGE = streamToList(IntStream.rangeClosed(100, 399));
 
     @Test
     public void parseToRangeShouldHandleEmptyString() {
         String value = "";
-        List<Range<Integer>> ranges = HttpRequest.DescriptorImpl.parseToRange(value);
-        assertEquals(DEFAULT_VALID_RESPONSE_CODES_RANGE, ranges);
+        List<IntStream> ranges = HttpRequest.DescriptorImpl.parseToRange(value);
+        assertEquals(1, ranges.size());
+        assertEquals(DEFAULT_VALID_RESPONSE_CODES_RANGE, streamToList(ranges.get(0)));
     }
 
     @Test
     public void parseToRangeShouldHandleNull() {
         String value = null;
-        List<Range<Integer>> ranges = HttpRequest.DescriptorImpl.parseToRange(value);
-        assertEquals(DEFAULT_VALID_RESPONSE_CODES_RANGE, ranges);
+        List<IntStream> ranges = HttpRequest.DescriptorImpl.parseToRange(value);
+        assertEquals(1, ranges.size());
+        assertEquals(DEFAULT_VALID_RESPONSE_CODES_RANGE, streamToList(ranges.get(0)));
+    }
+
+    private static List<Integer> streamToList(IntStream stream) {
+        return stream.boxed().collect(Collectors.toList());
     }
 }

--- a/src/test/java/jenkins/plugins/http_request/HttpRequestStepTest.java
+++ b/src/test/java/jenkins/plugins/http_request/HttpRequestStepTest.java
@@ -229,7 +229,7 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
         // Check expectations
         j.assertBuildStatus(Result.FAILURE, run);
         j.assertLogContains("Throwing status 400 for test",run);
-        j.assertLogContains("Fail: the returned code 400 is not in the accepted range: [[100‥399]]", run);
+        j.assertLogContains("Fail: the returned code 400 is not in the accepted range: 100:399", run);
     }
 
     @Test
@@ -426,7 +426,7 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
 
         // Check expectations
         j.assertBuildStatus(Result.FAILURE, run);
-        j.assertLogContains("Fail: the returned code 408 is not in the accepted range: [[100‥399]]", run);
+        j.assertLogContains("Fail: the returned code 408 is not in the accepted range: 100:399", run);
     }
 
     @Test

--- a/src/test/java/jenkins/plugins/http_request/HttpRequestStepTest.java
+++ b/src/test/java/jenkins/plugins/http_request/HttpRequestStepTest.java
@@ -229,6 +229,7 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
         // Check expectations
         j.assertBuildStatus(Result.FAILURE, run);
         j.assertLogContains("Throwing status 400 for test",run);
+        j.assertLogContains("Fail: the returned code 400 is not in the accepted range: [[100‥399]]", run);
     }
 
     @Test
@@ -274,6 +275,7 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
 
         // Check expectations
         j.assertBuildStatus(Result.FAILURE, run);
+        j.assertLogContains("Interval 599:100 should be FROM less than TO", run);
     }
 
     @Test
@@ -296,6 +298,7 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
 
         // Check expectations
         j.assertBuildStatus(Result.FAILURE, run);
+        j.assertLogContains("Invalid number text", run);
     }
 
     @Test
@@ -318,6 +321,7 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
 
         // Check expectations
         j.assertBuildStatus(Result.FAILURE, run);
+        j.assertLogContains("Invalid number text", run);
     }
 
     @Test
@@ -340,6 +344,7 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
 
         // Check expectations
         j.assertBuildStatus(Result.FAILURE, run);
+        j.assertLogContains("Code 1:2:3 should be an interval from:to or a single value", run);
     }
 
     @Test
@@ -421,6 +426,7 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
 
         // Check expectations
         j.assertBuildStatus(Result.FAILURE, run);
+        j.assertLogContains("Fail: the returned code 408 is not in the accepted range: [[100‥399]]", run);
     }
 
     @Test
@@ -463,6 +469,7 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
 
         // Check expectations
         j.assertBuildStatus(Result.FAILURE, run);
+        j.assertLogContains("Authentication 'invalid' doesn't exist anymore", run);
     }
 
     @Test
@@ -670,7 +677,7 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
         WorkflowJob proj = j.jenkins.createProject(WorkflowJob.class, "proj");
         proj.setDefinition(new CpsFlowDefinition(
                 "def response = httpRequest url:'"+baseURL()+"/proxyAuth',\n" +
-                        "    proxy: 'http://proxy.example.com:8080',\n" +
+                        "    httpProxy: 'http://proxy.example.com:8080',\n" +
                         "    proxyAuthentication: 'invalid'\n" +
                         "println('Status: '+response.getStatus())\n" +
                         "println('Response: '+response.getContent())\n",
@@ -681,5 +688,6 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
 
         // Check expectations
         j.assertBuildStatus(Result.FAILURE, run);
+        j.assertLogContains("Proxy authentication 'invalid' doesn't exist anymore or is not a username/password credential type", run);
     }
 }

--- a/src/test/java/jenkins/plugins/http_request/HttpRequestTest.java
+++ b/src/test/java/jenkins/plugins/http_request/HttpRequestTest.java
@@ -387,7 +387,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		// Check expectations
 		this.j.assertBuildStatus(Result.FAILURE, build);
 		this.j.assertLogContains("Throwing status 400 for test", build);
-		this.j.assertLogContains("Fail: the returned code 400 is not in the accepted range: [[100‥399]]", build);
+		this.j.assertLogContains("Fail: the returned code 400 is not in the accepted range: 100:399", build);
 	}
 
 	@Test
@@ -633,7 +633,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 
 		// Check expectations
 		this.j.assertBuildStatus(Result.FAILURE, build);
-		this.j.assertLogContains("Fail: the returned code 408 is not in the accepted range: [[100‥399]]", build);
+		this.j.assertLogContains("Fail: the returned code 408 is not in the accepted range: 100:399", build);
 	}
 
 	@Test

--- a/src/test/java/jenkins/plugins/http_request/HttpRequestTest.java
+++ b/src/test/java/jenkins/plugins/http_request/HttpRequestTest.java
@@ -387,6 +387,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		// Check expectations
 		this.j.assertBuildStatus(Result.FAILURE, build);
 		this.j.assertLogContains("Throwing status 400 for test", build);
+		this.j.assertLogContains("Fail: the returned code 400 is not in the accepted range: [[100‥399]]", build);
 	}
 
 	@Test
@@ -426,6 +427,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 
 		// Check expectations
 		this.j.assertBuildStatus(Result.FAILURE, build);
+		this.j.assertLogContains("Interval 599:100 should be FROM less than TO", build);
 	}
 
 	@Test
@@ -445,6 +447,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 
 		// Check expectations
 		this.j.assertBuildStatus(Result.FAILURE, build);
+		this.j.assertLogContains("Invalid number text", build);
 	}
 
 	@Test
@@ -464,6 +467,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 
 		// Check expectations
 		this.j.assertBuildStatus(Result.FAILURE, build);
+		this.j.assertLogContains("Invalid number text", build);
 	}
 
 	@Test
@@ -483,6 +487,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 
 		// Check expectations
 		this.j.assertBuildStatus(Result.FAILURE, build);
+		this.j.assertLogContains("Code 1:2:3 should be an interval from:to or a single value", build);
 	}
 
 	@Test
@@ -628,6 +633,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 
 		// Check expectations
 		this.j.assertBuildStatus(Result.FAILURE, build);
+		this.j.assertLogContains("Fail: the returned code 408 is not in the accepted range: [[100‥399]]", build);
 	}
 
 	@Test
@@ -704,6 +710,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 
 		// Check expectations
 		this.j.assertBuildStatus(Result.FAILURE, build);
+		this.j.assertLogContains("Authentication 'non-existent-key' doesn't exist anymore", build);
 	}
 
 	@Test
@@ -1019,6 +1026,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 
 		// Check expectations
 		this.j.assertBuildStatus(Result.FAILURE, build);
+		this.j.assertLogContains("Proxy authentication 'non-existent-key' doesn't exist anymore or is not a username/password credential type", build);
 	}
 
 }


### PR DESCRIPTION
`com.google.common.collect.Ranges` was removed in Guava 15, so consuming this API is a liability. This PR replaces usages of `com.google.common.collect.Range` and `com.google.common.collect.Ranges` with usages of  `java.util.stream.IntStream` to avoid any breakage when running on newer versions of Guava.

Before I started this change, I improved the tests to ensure that they were checking for the appropriate error messages for range violations. This gave me confidence that my refactoring was successful. Along the way, I found and fixed a bug in one of the tests as well.