### PR TITLE
Deprecated step API replaced

### DIFF
--- a/src/main/java/jenkins/plugins/http_request/HttpRequest.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequest.java
@@ -52,7 +52,7 @@ import jenkins.plugins.http_request.util.HttpRequestNameValuePair;
  */
 public class HttpRequest extends Builder {
 
-    private @NonNull String url;
+	private final @NonNull String url;
 	private Boolean ignoreSslErrors = DescriptorImpl.ignoreSslErrors;
 	private HttpMode httpMode                 = DescriptorImpl.httpMode;
 	private String httpProxy                  = DescriptorImpl.httpProxy;

--- a/src/main/java/jenkins/plugins/http_request/HttpRequestExecution.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestExecution.java
@@ -135,7 +135,8 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 		}
 	}
 
-	static HttpRequestExecution from(HttpRequestStep step, TaskListener taskListener, Execution execution) {
+	static HttpRequestExecution from(HttpRequestStep step, TaskListener taskListener, Execution execution)
+			throws IOException, InterruptedException {
 		List<HttpRequestNameValuePair> headers = step.resolveHeaders();
 		FilePath outputFile = execution.resolveOutputFile();
 		FilePath uploadFile = execution.resolveUploadFile();

--- a/src/main/java/jenkins/plugins/http_request/HttpRequestStep.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestStep.java
@@ -314,6 +314,7 @@ public final class HttpRequestStep extends AbstractStepImpl {
             return "httpRequest";
         }
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Perform an HTTP Request and return a response object";

--- a/src/main/java/jenkins/plugins/http_request/HttpRequestStep.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestStep.java
@@ -432,12 +432,8 @@ public final class HttpRequestStep extends Step {
 			}
 		}
 
-		public Item getProject() {
-			try {
-				return Objects.requireNonNull(getContext().get(Run.class)).getParent();
-			} catch (IOException | InterruptedException e) {
-				throw new IllegalStateException(e);
-			}
+		public Item getProject() throws IOException, InterruptedException {
+			return Objects.requireNonNull(getContext().get(Run.class)).getParent();
 		}
 	}
 }

--- a/src/main/java/jenkins/plugins/http_request/HttpRequestStep.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestStep.java
@@ -35,7 +35,7 @@ import jenkins.plugins.http_request.util.HttpRequestNameValuePair;
  */
 public final class HttpRequestStep extends AbstractStepImpl {
 
-    private @NonNull String url;
+    private final @NonNull String url;
 	private boolean ignoreSslErrors = DescriptorImpl.ignoreSslErrors;
 	private HttpMode httpMode                 = DescriptorImpl.httpMode;
     private String httpProxy                  = DescriptorImpl.httpProxy;

--- a/src/main/java/jenkins/plugins/http_request/ResponseContentSupplier.java
+++ b/src/main/java/jenkins/plugins/http_request/ResponseContentSupplier.java
@@ -34,8 +34,8 @@ public class ResponseContentSupplier implements Serializable, AutoCloseable {
 
 	private static final long serialVersionUID = 1L;
 
-	private int status;
-	private Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+	private final int status;
+	private final Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 	private String charset;
 
 	private ResponseHandle responseHandle;

--- a/src/main/java/jenkins/plugins/http_request/auth/BasicDigestAuthentication.java
+++ b/src/main/java/jenkins/plugins/http_request/auth/BasicDigestAuthentication.java
@@ -10,6 +10,7 @@ import org.apache.http.protocol.HttpContext;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
@@ -72,6 +73,7 @@ public class BasicDigestAuthentication extends AbstractDescribableImpl<BasicDige
             return FormValidation.validateRequired(value);
         }
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Basic/Digest Authentication";

--- a/src/main/java/jenkins/plugins/http_request/auth/FormAuthentication.java
+++ b/src/main/java/jenkins/plugins/http_request/auth/FormAuthentication.java
@@ -14,6 +14,7 @@ import org.apache.http.protocol.HttpContext;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
@@ -72,6 +73,7 @@ public class FormAuthentication extends AbstractDescribableImpl<FormAuthenticati
             return HttpRequestGlobalConfig.validateKeyName(value);
         }
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Form Authentication";


### PR DESCRIPTION
Implementations of deprecated `AbstractStepImpl` / `AbstractSynchronousNonBlockingStepExecution` replaced.

Additionally some minor improvements (`final` and `@NonNull` related), missed in the previous PR.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
