### PR TITLE
"Success code from java.util.stream.IntPipeline$Head@53822a2e" printed on success

### DIFF
--- a/src/main/java/jenkins/plugins/http_request/HttpRequestExecution.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestExecution.java
@@ -407,11 +407,11 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 		List<IntStream> ranges = DescriptorImpl.parseToRange(validResponseCodes);
 		for (IntStream range : ranges) {
 			if (range.anyMatch(status -> status == response.getStatus())) {
-				logger().println("Success code from " + range);
+				logger().println("Success: Status code " + response.getStatus() + " is in the accepted range: " + validResponseCodes);
 				return;
 			}
 		}
-		throw new AbortException("Fail: the returned code " + response.getStatus() + " is not in the accepted range: " + validResponseCodes);
+		throw new AbortException("Fail: Status code " + response.getStatus() + " is not in the accepted range: " + validResponseCodes);
 	}
 
 	private void processResponse(ResponseContentSupplier response) throws IOException, InterruptedException {

--- a/src/test/java/jenkins/plugins/http_request/HttpRequestStepTest.java
+++ b/src/test/java/jenkins/plugins/http_request/HttpRequestStepTest.java
@@ -65,6 +65,7 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
         j.assertBuildStatusSuccess(run);
         j.assertLogContains("Status: 200",run);
         j.assertLogContains("Response: "+ ALL_IS_WELL,run);
+        j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", run);
     }
 
     @Test
@@ -114,6 +115,7 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
         // Check expectations
         j.assertBuildStatusSuccess(run);
         j.assertLogContains(findMe,run);
+        j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", run);
     }
 
     @Test
@@ -137,6 +139,7 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
         // Check expectations
         j.assertBuildStatus(Result.FAILURE, run);
         j.assertLogContains("Fail: Response doesn't contain expected content 'bad content'", run);
+        j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", run);
     }
 
     @Test
@@ -160,6 +163,7 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
         // Check expectations
         j.assertBuildStatusSuccess(run);
         j.assertLogContains(ALL_IS_WELL,run);
+        j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", run);
     }
 
     @Test
@@ -183,6 +187,7 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
         // Check expectations
         j.assertBuildStatusSuccess(run);
         j.assertLogContains(ALL_IS_WELL,run);
+        j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", run);
     }
 
     @Test
@@ -216,6 +221,7 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
         if (mode == HttpMode.HEAD) return;
 
         j.assertLogContains(ALL_IS_WELL,run);
+        j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", run);
     }
 
     @Test
@@ -238,7 +244,7 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
         // Check expectations
         j.assertBuildStatus(Result.FAILURE, run);
         j.assertLogContains("Throwing status 400 for test",run);
-        j.assertLogContains("Fail: the returned code 400 is not in the accepted range: 100:399", run);
+        j.assertLogContains("Fail: Status code 400 is not in the accepted range: 100:399", run);
     }
 
     @Test
@@ -262,6 +268,7 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
         // Check expectations
         j.assertBuildStatusSuccess(run);
         j.assertLogContains("Throwing status 400 for test",run);
+        j.assertLogContains("Success: Status code 400 is in the accepted range: 100:599", run);
     }
 
     @Test
@@ -384,6 +391,7 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
         // Check expectations
         j.assertBuildStatusSuccess(run);
         j.assertLogContains(ALL_IS_WELL,run);
+        j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", run);
     }
 
     @Test
@@ -414,6 +422,7 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
         // Check expectations
         j.assertBuildStatusSuccess(run);
         j.assertLogContains(ALL_IS_WELL,run);
+        j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", run);
     }
 
     @Test
@@ -435,7 +444,7 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
 
         // Check expectations
         j.assertBuildStatus(Result.FAILURE, run);
-        j.assertLogContains("Fail: the returned code 408 is not in the accepted range: 100:399", run);
+        j.assertLogContains("Fail: Status code 408 is not in the accepted range: 100:399", run);
     }
 
     @Test
@@ -456,7 +465,8 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
         WorkflowRun run = proj.scheduleBuild2(0).get();
 
         // Check expectations
-        j.assertBuildStatus(Result.SUCCESS, run);
+        j.assertBuildStatusSuccess(run);
+        j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", run);
     }
 
     @Test
@@ -503,7 +513,8 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
         WorkflowRun run = proj.scheduleBuild2(0).get();
 
         // Check expectations
-        j.assertBuildStatus(Result.SUCCESS, run);
+        j.assertBuildStatusSuccess(run);
+        j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", run);
     }
 
     @Test
@@ -539,7 +550,8 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
         WorkflowRun run = proj.scheduleBuild2(0).get();
 
         // Check expectations
-        j.assertBuildStatus(Result.SUCCESS, run);
+        j.assertBuildStatusSuccess(run);
+        j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", run);
     }
 
     @Test
@@ -643,6 +655,7 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
         // Check expectations
         j.assertBuildStatusSuccess(run);
         j.assertLogContains("Response: " + body, run);
+        j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", run);
     }
 
     @Test
@@ -675,6 +688,7 @@ public class HttpRequestStepTest extends HttpRequestTestBase {
         // Check expectations
         j.assertBuildStatusSuccess(run);
         j.assertLogContains(responseText, run);
+        j.assertLogContains("Success: Status code 201 is in the accepted range: 201", run);
     }
 
     @Test

--- a/src/test/java/jenkins/plugins/http_request/HttpRequestTest.java
+++ b/src/test/java/jenkins/plugins/http_request/HttpRequestTest.java
@@ -78,6 +78,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		// Check expectations
 		this.j.assertBuildStatusSuccess(build);
 		this.j.assertLogContains(ALL_IS_WELL, build);
+		this.j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", build);
 	}
 
 	@Test
@@ -123,6 +124,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		// Check expectations
 		this.j.assertBuildStatusSuccess(build);
 		this.j.assertLogContains(findMe, build);
+		this.j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", build);
 	}
 
 	@Test
@@ -143,6 +145,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		// Check expectations
 		this.j.assertBuildStatus(Result.FAILURE, build);
 		this.j.assertLogContains("Fail: Response doesn't contain expected content 'bad content'", build);
+		this.j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", build);
 	}
 
 	@Test
@@ -165,6 +168,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		// Check expectations
 		this.j.assertBuildStatusSuccess(build);
 		this.j.assertLogContains(ALL_IS_WELL, build);
+		this.j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", build);
 	}
 
 	@Test
@@ -187,6 +191,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		// Check expectations
 		this.j.assertBuildStatusSuccess(build);
 		this.j.assertLogContains(ALL_IS_WELL, build);
+		this.j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", build);
 	}
 
 	@Test
@@ -212,6 +217,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		// Check expectations
 		this.j.assertBuildStatusSuccess(build);
 		this.j.assertLogContains(ALL_IS_WELL, build);
+		this.j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", build);
 	}
 
 	@Test
@@ -245,6 +251,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		// Check expectations
 		this.j.assertBuildStatusSuccess(build);
 		this.j.assertLogContains(ALL_IS_WELL, build);
+		this.j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", build);
 	}
 
 	@Test
@@ -267,6 +274,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		// Check expectations
 		this.j.assertBuildStatusSuccess(build);
 		this.j.assertLogContains(ALL_IS_WELL, build);
+		this.j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", build);
 	}
 
 	@Test
@@ -289,6 +297,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		// Check expectations
 		this.j.assertBuildStatusSuccess(build);
 		this.j.assertLogContains(ALL_IS_WELL, build);
+		this.j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", build);
 	}
 
 	@Test
@@ -312,6 +321,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		// Check expectations
 		this.j.assertBuildStatusSuccess(build);
 		this.j.assertLogContains(ALL_IS_WELL, build);
+		this.j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", build);
 	}
 
 	@Test
@@ -334,6 +344,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		// Check expectations
 		this.j.assertBuildStatusSuccess(build);
 		this.j.assertLogContains(ALL_IS_WELL, build);
+		this.j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", build);
 	}
 
 	@Test
@@ -366,6 +377,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		}
 
 		this.j.assertLogContains(ALL_IS_WELL, build);
+		this.j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", build);
 	}
 
 	@Test
@@ -385,7 +397,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		// Check expectations
 		this.j.assertBuildStatus(Result.FAILURE, build);
 		this.j.assertLogContains("Throwing status 400 for test", build);
-		this.j.assertLogContains("Fail: the returned code 400 is not in the accepted range: 100:399", build);
+		this.j.assertLogContains("Fail: Status code 400 is not in the accepted range: 100:399", build);
 	}
 
 	@Test
@@ -406,6 +418,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		// Check expectations
 		this.j.assertBuildStatusSuccess(build);
 		this.j.assertLogContains("Throwing status 400 for test", build);
+		this.j.assertLogContains("Success: Status code 400 is in the accepted range: 100:599", build);
 	}
 
 	@Test
@@ -517,6 +530,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		// Check expectations
 		this.j.assertBuildStatusSuccess(build);
 		this.j.assertLogContains(checkMessage, build);
+		this.j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", build);
 	}
 
     @Test
@@ -557,6 +571,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		// Check expectations
 		this.j.assertBuildStatusSuccess(build);
 		this.j.assertLogContains(ALL_IS_WELL, build);
+		this.j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", build);
 	}
 
 	@Test
@@ -585,6 +600,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		Pattern p = Pattern.compile(ALL_IS_WELL);
 		Matcher m = p.matcher(outputFile);
 		assertTrue(m.find());
+		this.j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", build);
 	}
 
 	@Test
@@ -612,6 +628,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		Pattern p = Pattern.compile(ALL_IS_WELL);
 		Matcher m = p.matcher(outputFile);
 		assertTrue(m.find());
+		this.j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", build);
 	}
 
 	@Test
@@ -631,7 +648,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 
 		// Check expectations
 		this.j.assertBuildStatus(Result.FAILURE, build);
-		this.j.assertLogContains("Fail: the returned code 408 is not in the accepted range: 100:399", build);
+		this.j.assertLogContains("Fail: Status code 408 is not in the accepted range: 100:399", build);
 	}
 
 	@Test
@@ -651,7 +668,8 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		FreeStyleBuild build = project.scheduleBuild2(0).get();
 
 		// Check expectations
-		this.j.assertBuildStatus(Result.SUCCESS, build);
+		this.j.assertBuildStatusSuccess(build);
+		this.j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", build);
 	}
 
 	@Test
@@ -687,8 +705,9 @@ public class HttpRequestTest extends HttpRequestTestBase {
 				new ParametersAction(new StringParameterValue("Tag", "trunk"), new StringParameterValue("WORKSPACE", "C:/path/to/my/workspace"))).get();
 
 		// Check expectations
-		this.j.assertBuildStatus(Result.SUCCESS, build);
+		this.j.assertBuildStatusSuccess(build);
 		this.j.assertLogContains(ALL_IS_WELL, build);
+		this.j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", build);
 	}
 
 	@Test
@@ -730,7 +749,8 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		FreeStyleBuild build = project.scheduleBuild2(0).get();
 
 		// Check expectations
-		this.j.assertBuildStatus(Result.SUCCESS, build);
+		this.j.assertBuildStatusSuccess(build);
+		this.j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", build);
 	}
 
 	@Test
@@ -799,7 +819,8 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		FreeStyleBuild build = project.scheduleBuild2(0).get();
 
 		// Check expectations
-		this.j.assertBuildStatus(Result.SUCCESS, build);
+		this.j.assertBuildStatusSuccess(build);
+		this.j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", build);
 	}
 
 	@Test
@@ -832,7 +853,8 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		FreeStyleBuild build = project.scheduleBuild2(0).get();
 
 		// Check expectations
-		this.j.assertBuildStatus(Result.SUCCESS, build);
+		this.j.assertBuildStatusSuccess(build);
+		this.j.assertLogContains("Success: Status code 200 is in the accepted range: 100:399", build);
 	}
 
 	@Test
@@ -977,6 +999,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		// Check expectations
 		this.j.assertBuildStatusSuccess(build);
 		this.j.assertLogContains(responseText, build);
+		this.j.assertLogContains("Success: Status code 201 is in the accepted range: 201", build);
 	}
 
 	@Test
@@ -1005,6 +1028,7 @@ public class HttpRequestTest extends HttpRequestTestBase {
 		// Check expectations
 		this.j.assertBuildStatusSuccess(build);
 		this.j.assertLogContains(responseText, build);
+		this.j.assertLogContains("Success: Status code 201 is in the accepted range: 201", build);
 	}
 
 	@Test


### PR DESCRIPTION
Fixes a minor bug introduced in #63 and adds test coverage for the success case.