### PR TITLE
Remove @janario GitHub Sponsorship

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-github: janario


### PR DESCRIPTION
@janario has been inactive in this repository for more than one year. @basil and me have stepped up in the past year to deliver fixes critical to the Jenkins core. I suggest removing GitHub sponsorship for individual account
