### PR TITLE
[SECURITY-2053] Prevent plain text credentials of Basic/Digest authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@ THE SOFTWARE.
 		<changelist>-SNAPSHOT</changelist>
 		<gitHubRepo>jenkinsci/http-request-plugin</gitHubRepo>
 		<jenkins.version>2.249.1</jenkins.version>
-		<hpi.compatibleSinceVersion>1.8.17</hpi.compatibleSinceVersion>
+		<hpi.compatibleSinceVersion>1.16</hpi.compatibleSinceVersion>
 	</properties>
 
 	<repositories>

--- a/src/main/java/jenkins/plugins/http_request/HttpRequest.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequest.java
@@ -42,7 +42,6 @@ import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.util.ListBoxModel.Option;
 
-import jenkins.plugins.http_request.auth.BasicDigestAuthentication;
 import jenkins.plugins.http_request.auth.FormAuthentication;
 import jenkins.plugins.http_request.util.HttpClientUtil;
 import jenkins.plugins.http_request.util.HttpRequestFormDataPart;

--- a/src/main/java/jenkins/plugins/http_request/HttpRequest.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequest.java
@@ -536,10 +536,6 @@ public class HttpRequest extends Builder {
 			}
 
 			List<Option> options = new ArrayList<>();
-			for (BasicDigestAuthentication basic : HttpRequestGlobalConfig.get().getBasicDigestAuthentications()) {
-				options.add(new Option("(deprecated - use Jenkins Credentials) " +
-						basic.getKeyName(), basic.getKeyName()));
-            }
 
             for (FormAuthentication formAuthentication : HttpRequestGlobalConfig.get().getFormAuthentications()) {
 				options.add(new Option(formAuthentication.getKeyName()));

--- a/src/main/java/jenkins/plugins/http_request/HttpRequestGlobalConfig.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestGlobalConfig.java
@@ -109,10 +109,7 @@ public class HttpRequestGlobalConfig extends GlobalConfiguration {
     }
 
     public List<Authenticator> getAuthentications() {
-        List<Authenticator> list = new ArrayList<>();
-        list.addAll(basicDigestAuthentications);
-        list.addAll(formAuthentications);
-        return list;
+		return new ArrayList<>(formAuthentications);
     }
 
     public Authenticator getAuthentication(String keyName) {

--- a/src/main/java/jenkins/plugins/http_request/HttpRequestGlobalConfig.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestGlobalConfig.java
@@ -109,7 +109,7 @@ public class HttpRequestGlobalConfig extends GlobalConfiguration {
     }
 
     public List<Authenticator> getAuthentications() {
-		return new ArrayList<>(formAuthentications);
+        return new ArrayList<>(formAuthentications);
     }
 
     public Authenticator getAuthentication(String keyName) {
@@ -121,8 +121,8 @@ public class HttpRequestGlobalConfig extends GlobalConfiguration {
         return null;
     }
 
-	protected Object readResolve() {
-		this.basicDigestAuthentications = new ArrayList<>();
-		return this;
-	}
+    protected Object readResolve() {
+        this.basicDigestAuthentications = new ArrayList<>();
+        return this;
+    }
 }

--- a/src/main/java/jenkins/plugins/http_request/HttpRequestGlobalConfig.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestGlobalConfig.java
@@ -28,6 +28,10 @@ import jenkins.plugins.http_request.util.HttpRequestNameValuePair;
 @Extension
 public class HttpRequestGlobalConfig extends GlobalConfiguration {
 
+    /**
+     * @deprecated removed without replacement
+     */
+    @Deprecated
     private transient List<BasicDigestAuthentication> basicDigestAuthentications = new ArrayList<>();
     private List<FormAuthentication> formAuthentications = new ArrayList<>();
 
@@ -78,17 +82,18 @@ public class HttpRequestGlobalConfig extends GlobalConfiguration {
         return GlobalConfiguration.all().get(HttpRequestGlobalConfig.class);
     }
 
-	/**
-	 * @deprecated SECURITY-2053: Avoid using Basic Digest Authentication
-	 */
-	@Deprecated
+    /**
+     * @deprecated removed without replacement
+     */
+    @Deprecated
     public List<BasicDigestAuthentication> getBasicDigestAuthentications() {
         return basicDigestAuthentications;
     }
 
-	/**
-	 * @deprecated SECURITY-2053: Avoid using Basic Digest Authentication
-	 */
+    /**
+     * @deprecated removed without replacement
+     */
+    @Deprecated
     public void setBasicDigestAuthentications(
             List<BasicDigestAuthentication> basicDigestAuthentications) {
         this.basicDigestAuthentications = basicDigestAuthentications;

--- a/src/main/java/jenkins/plugins/http_request/HttpRequestGlobalConfig.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestGlobalConfig.java
@@ -122,7 +122,9 @@ public class HttpRequestGlobalConfig extends GlobalConfiguration {
     }
 
     protected Object readResolve() {
-        this.basicDigestAuthentications = new ArrayList<>();
+        if (this.basicDigestAuthentications != null) {
+            this.basicDigestAuthentications = new ArrayList<>();
+        }
         return this;
     }
 }

--- a/src/main/java/jenkins/plugins/http_request/HttpRequestGlobalConfig.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestGlobalConfig.java
@@ -8,7 +8,6 @@ import net.sf.json.JSONObject;
 
 import org.kohsuke.stapler.StaplerRequest;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.XmlFile;
 import hudson.init.InitMilestone;

--- a/src/main/java/jenkins/plugins/http_request/HttpRequestGlobalConfig.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestGlobalConfig.java
@@ -120,4 +120,9 @@ public class HttpRequestGlobalConfig extends GlobalConfiguration {
         }
         return null;
     }
+
+	protected Object readResolve() {
+		this.basicDigestAuthentications = new ArrayList<>();
+		return this;
+	}
 }

--- a/src/main/java/jenkins/plugins/http_request/HttpRequestGlobalConfig.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestGlobalConfig.java
@@ -8,6 +8,7 @@ import net.sf.json.JSONObject;
 
 import org.kohsuke.stapler.StaplerRequest;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.XmlFile;
 import hudson.init.InitMilestone;
@@ -28,7 +29,7 @@ import jenkins.plugins.http_request.util.HttpRequestNameValuePair;
 @Extension
 public class HttpRequestGlobalConfig extends GlobalConfiguration {
 
-    private List<BasicDigestAuthentication> basicDigestAuthentications = new ArrayList<>();
+    private transient List<BasicDigestAuthentication> basicDigestAuthentications = new ArrayList<>();
     private List<FormAuthentication> formAuthentications = new ArrayList<>();
 
     private static final XStream2 XSTREAM2 = new XStream2();
@@ -78,10 +79,17 @@ public class HttpRequestGlobalConfig extends GlobalConfiguration {
         return GlobalConfiguration.all().get(HttpRequestGlobalConfig.class);
     }
 
+	/**
+	 * @deprecated SECURITY-2053: Avoid using Basic Digest Authentication
+	 */
+	@Deprecated
     public List<BasicDigestAuthentication> getBasicDigestAuthentications() {
         return basicDigestAuthentications;
     }
 
+	/**
+	 * @deprecated SECURITY-2053: Avoid using Basic Digest Authentication
+	 */
     public void setBasicDigestAuthentications(
             List<BasicDigestAuthentication> basicDigestAuthentications) {
         this.basicDigestAuthentications = basicDigestAuthentications;

--- a/src/main/java/jenkins/plugins/http_request/auth/BasicDigestAuthentication.java
+++ b/src/main/java/jenkins/plugins/http_request/auth/BasicDigestAuthentication.java
@@ -11,6 +11,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
@@ -27,9 +28,12 @@ public class BasicDigestAuthentication extends AbstractDescribableImpl<BasicDige
         implements Authenticator {
 	private static final long serialVersionUID = 4818288270720177069L;
 
-	private final String keyName;
-    private final String userName;
-    private final String password;
+	@SuppressFBWarnings(value="SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "SECURITY-2053:Field should not be serialized")
+	private transient final String keyName;
+	@SuppressFBWarnings(value="SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "SECURITY-2053:Field should not be serialized")
+    private transient final String userName;
+	@SuppressFBWarnings(value="SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "SECURITY-2053:Field should not be serialized")
+    private transient final String password;
 
     @DataBoundConstructor
     public BasicDigestAuthentication(String keyName, String userName,

--- a/src/main/java/jenkins/plugins/http_request/auth/BasicDigestAuthentication.java
+++ b/src/main/java/jenkins/plugins/http_request/auth/BasicDigestAuthentication.java
@@ -11,7 +11,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
@@ -28,12 +27,9 @@ public class BasicDigestAuthentication extends AbstractDescribableImpl<BasicDige
         implements Authenticator {
 	private static final long serialVersionUID = 4818288270720177069L;
 
-	@SuppressFBWarnings(value="SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "SECURITY-2053:Field should not be serialized")
-	private transient final String keyName;
-	@SuppressFBWarnings(value="SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "SECURITY-2053:Field should not be serialized")
-    private transient final String userName;
-	@SuppressFBWarnings(value="SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "SECURITY-2053:Field should not be serialized")
-    private transient final String password;
+	private final String keyName;
+    private final String userName;
+    private final String password;
 
     @DataBoundConstructor
     public BasicDigestAuthentication(String keyName, String userName,

--- a/src/main/resources/jenkins/plugins/http_request/HttpRequestGlobalConfig/config.jelly
+++ b/src/main/resources/jenkins/plugins/http_request/HttpRequestGlobalConfig/config.jelly
@@ -18,27 +18,6 @@
 		</d:tag>
 	</d:taglib>
     <f:section title="HTTP Request">
-    	<f:entry title="DEPRECATED (use Jenkins credentials) Basic/Digest Authentication">
-            <f:repeatable field="basicDigestAuthentications">
-				<local:blockWrapper>
-                    <f:entry title="Key Name" field="keyName" help="/plugin/http_request/help-keyName.html">
-                        <f:textbox />
-                    </f:entry>
-                    <f:entry title="Username" field="userName" help="/plugin/http_request/help-userName.html">
-                        <f:textbox />
-                    </f:entry>
-                    <f:entry title="Password" field="password" help="/plugin/http_request/help-password.html">
-                        <f:password />
-                    </f:entry>
-                    <f:entry title="">
-                        <div align="right">
-                            <f:repeatableDeleteButton />
-                        </div>
-                    </f:entry>
-				</local:blockWrapper>
-            </f:repeatable>
-        </f:entry>
-
         <f:entry title="Form Authentication">
             <f:repeatable field="formAuthentications">
                 <local:blockWrapper>

--- a/src/main/webapp/help-password.html
+++ b/src/main/webapp/help-password.html
@@ -1,3 +1,0 @@
-<div>
-    Password for this authentication
-</div>

--- a/src/main/webapp/help-userName.html
+++ b/src/main/webapp/help-userName.html
@@ -1,3 +1,0 @@
-<div>
-    Username for this authentication
-</div>

--- a/src/test/java/jenkins/plugins/http_request/HttpRequestBackwardCompatibilityTest.java
+++ b/src/test/java/jenkins/plugins/http_request/HttpRequestBackwardCompatibilityTest.java
@@ -47,16 +47,7 @@ public class HttpRequestBackwardCompatibilityTest {
         HttpRequestGlobalConfig cfg = HttpRequestGlobalConfig.get();
 
         List<BasicDigestAuthentication> bdas = cfg.getBasicDigestAuthentications();
-        assertEquals(2,bdas.size());
-		Iterator<BasicDigestAuthentication> itr = bdas.iterator();
-		BasicDigestAuthentication bda = itr.next();
-		assertEquals("k1",bda.getKeyName());
-        assertEquals("u1",bda.getUserName());
-        assertEquals("p1",bda.getPassword());
-		bda = itr.next();
-		assertEquals("k2",bda.getKeyName());
-        assertEquals("u2",bda.getUserName());
-        assertEquals("p2",bda.getPassword());
+        assertEquals(0,bdas.size());
 
         List<FormAuthentication> fas = cfg.getFormAuthentications();
         assertEquals(1,fas.size());

--- a/src/test/java/jenkins/plugins/http_request/HttpRequestBackwardCompatibilityTest.java
+++ b/src/test/java/jenkins/plugins/http_request/HttpRequestBackwardCompatibilityTest.java
@@ -15,7 +15,6 @@ import org.jvnet.hudson.test.recipes.LocalData;
 import hudson.model.FreeStyleProject;
 import hudson.tasks.Builder;
 
-import jenkins.plugins.http_request.auth.BasicDigestAuthentication;
 import jenkins.plugins.http_request.auth.FormAuthentication;
 import jenkins.plugins.http_request.util.HttpRequestNameValuePair;
 import jenkins.plugins.http_request.util.RequestAction;
@@ -33,7 +32,6 @@ public class HttpRequestBackwardCompatibilityTest {
     public void defaultGlobalConfig() {
         // Test that config from 1.8.6 can be loaded
         HttpRequestGlobalConfig cfg = HttpRequestGlobalConfig.get();
-        assertEquals(Collections.emptyList(), cfg.getBasicDigestAuthentications());
         assertEquals(Collections.emptyList(), cfg.getFormAuthentications());
         assertEquals("jenkins.plugins.http_request.HttpRequest.xml", cfg.getConfigFile().getFile().getName());
     }
@@ -45,9 +43,6 @@ public class HttpRequestBackwardCompatibilityTest {
         // Specifically tests the HttpRequestGlobalConfig.xStreamCompatibility() method
         // and the HttpRequestGlobalConfig.getConfigFile() method
         HttpRequestGlobalConfig cfg = HttpRequestGlobalConfig.get();
-
-        List<BasicDigestAuthentication> bdas = cfg.getBasicDigestAuthentications();
-        assertEquals(0,bdas.size());
 
         List<FormAuthentication> fas = cfg.getFormAuthentications();
         assertEquals(1,fas.size());

--- a/src/test/java/jenkins/plugins/http_request/HttpRequestRoundTripTest.java
+++ b/src/test/java/jenkins/plugins/http_request/HttpRequestRoundTripTest.java
@@ -10,7 +10,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
-import jenkins.plugins.http_request.auth.BasicDigestAuthentication;
 import jenkins.plugins.http_request.auth.FormAuthentication;
 import jenkins.plugins.http_request.util.HttpRequestNameValuePair;
 import jenkins.plugins.http_request.util.RequestAction;
@@ -62,10 +61,6 @@ public class HttpRequestRoundTripTest {
 
     @Test
     public void configRoundtripGroup3() throws Exception {
-        List<BasicDigestAuthentication> bda = new ArrayList<>();
-        bda.add(new BasicDigestAuthentication("keyname1","username1","password1"));
-        bda.add(new BasicDigestAuthentication("keyname2","username2","password2"));
-        HttpRequestGlobalConfig.get().setBasicDigestAuthentications(bda);
         configRoundTrip(before);
 
         List<HttpRequestNameValuePair> params = new ArrayList<>();
@@ -115,18 +110,6 @@ public class HttpRequestRoundTripTest {
           HttpRequestNameValuePair anvp = after.getCustomHeaders().get(idx);
           assertEquals(bnvp.getName(),anvp.getName());
           assertEquals(bnvp.getValue(),anvp.getValue());
-        }
-
-        // Basic authentication check
-        List<BasicDigestAuthentication> beforeBdas = HttpRequestGlobalConfig.get().getBasicDigestAuthentications();
-        List<BasicDigestAuthentication> afterBdas  = HttpRequestGlobalConfig.get().getBasicDigestAuthentications();
-        assertEquals(beforeBdas.size(), afterBdas.size());
-        for (int idx = 0; idx < beforeBdas.size(); idx++) {
-            BasicDigestAuthentication beforeBda = beforeBdas.get(idx);
-            BasicDigestAuthentication afterBda = afterBdas.get(idx);
-            assertEquals(beforeBda.getKeyName(), afterBda.getKeyName());
-            assertEquals(beforeBda.getUserName(),afterBda.getUserName());
-            assertEquals(beforeBda.getPassword(),afterBda.getPassword());
         }
 
         // Form authentication check

--- a/src/test/java/jenkins/plugins/http_request/HttpRequestStepRoundTripTest.java
+++ b/src/test/java/jenkins/plugins/http_request/HttpRequestStepRoundTripTest.java
@@ -4,7 +4,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
-import jenkins.plugins.http_request.auth.BasicDigestAuthentication;
 import jenkins.plugins.http_request.auth.FormAuthentication;
 import jenkins.plugins.http_request.util.HttpRequestNameValuePair;
 import jenkins.plugins.http_request.util.RequestAction;
@@ -54,10 +53,6 @@ public class HttpRequestStepRoundTripTest {
 
     @Test
     public void configRoundtripGroup3() throws Exception {
-        List<BasicDigestAuthentication> bda = new ArrayList<>();
-        bda.add(new BasicDigestAuthentication("keyname1","username1","password1"));
-        bda.add(new BasicDigestAuthentication("keyname2","username2","password2"));
-        HttpRequestGlobalConfig.get().setBasicDigestAuthentications(bda);
         configRoundTrip(before);
 
         List<HttpRequestNameValuePair> params = new ArrayList<>();
@@ -110,18 +105,6 @@ public class HttpRequestStepRoundTripTest {
           HttpRequestNameValuePair anvp = after.getCustomHeaders().get(idx);
           assertEquals(bnvp.getName(),anvp.getName());
           assertEquals(bnvp.getValue(),anvp.getValue());
-        }
-
-        // Basic authentication check
-        List<BasicDigestAuthentication> beforeBdas = HttpRequestGlobalConfig.get().getBasicDigestAuthentications();
-        List<BasicDigestAuthentication> afterBdas  = HttpRequestGlobalConfig.get().getBasicDigestAuthentications();
-        assertEquals(beforeBdas.size(), afterBdas.size());
-        for (int idx = 0; idx < beforeBdas.size(); idx++) {
-            BasicDigestAuthentication beforeBda = beforeBdas.get(idx);
-            BasicDigestAuthentication afterBda = afterBdas.get(idx);
-            assertEquals(beforeBda.getKeyName(), afterBda.getKeyName());
-            assertEquals(beforeBda.getUserName(),afterBda.getUserName());
-            assertEquals(beforeBda.getPassword(),afterBda.getPassword());
         }
 
         // Form authentication check


### PR DESCRIPTION
Removes Basic / Digest authentication in order to fix [SECURITY-2053](https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-2053).

It has been deprecated and marked for removal in 1.8.19+ anyway (we are 1.15 now).

:warning: There's *no* migration done for deprecated basic / digest authentications.

Here are my steps used to reproduce the issue and verify my fix:

#### Reproduce

1. Install the current version (1.15 or master)
1. Global settings --> Http request --> Basic/Digest Authentication
1. Add an entry (incl. username and password)
1. Save
1. Verify the plugins XML file contains data of _3.)_ in plain text

#### Verify the fix

1. Update to version of this PR
1. Basic/Digest Authentication is no longer available through UI (= no new plain credentials possible)
1. Saving after an edit will remove any existing plain text credentials from the XML

### Reviewer

@jenkinsci/http-request-plugin-developers and security team (@Wadeck @daniel-beck)

------------------------

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
