### PR TITLE
[JENKINS-69155] Snapshot authentication credentials

### DIFF
--- a/src/main/java/jenkins/plugins/http_request/HttpRequestExecution.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestExecution.java
@@ -200,7 +200,8 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 				CredentialsProvider.trackAll(run, credential);
 
 				if (credential instanceof StandardUsernamePasswordCredentials) {
-					this.proxyCredentials = (StandardUsernamePasswordCredentials) credential;
+					// create snapshot of credentials because it needs to be serialized to the agent
+					this.proxyCredentials = CredentialsProvider.snapshot((StandardUsernamePasswordCredentials) credential);
 				} else {
 					this.proxyCredentials = null;
 					throw new IllegalStateException("Proxy authentication '" + proxyAuthentication + "' doesn't exist anymore or is not a username/password credential type");
@@ -232,6 +233,8 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 				CredentialsProvider.trackAll(run, credential);
 
 				if (credential != null) {
+					// create snapshot of credential because it needs to be serialized to the agent
+					credential = CredentialsProvider.snapshot(credential);
 					if (credential instanceof StandardUsernamePasswordCredentials) {
 						if (this.useNtlm) {
 							auth = new CredentialNtlmAuthentication((StandardUsernamePasswordCredentials) credential);


### PR DESCRIPTION
Create snapshot of authentication credentials so that they can be properly
serialized to the agent.

https://github.com/jenkinsci/hashicorp-vault-plugin/issues/201#issuecomment-1195727345

Fixes: [JENKINS-69155](https://issues.jenkins.io/browse/JENKINS-69155)

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
