### PR TITLE
Use standard SpotBugs exclusion file name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,6 @@ THE SOFTWARE.
 		<jenkins.version>2.303.1</jenkins.version>
 		<spotbugs.failOnError>true</spotbugs.failOnError>
 		<spotbugs.threshold>Low</spotbugs.threshold>
-		<spotbugs.excludeFilterFile>${project.basedir}/src/spotbugs/spotbugs-excludes.xml</spotbugs.excludeFilterFile>
 		<hpi.compatibleSinceVersion>1.16</hpi.compatibleSinceVersion>
 	</properties>
 

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <FindBugsFilter>
   <!--
     Exclusions in this section have been triaged and determined to be false positives.


### PR DESCRIPTION
https://github.com/jenkinsci/plugin-pom/blob/61707aa156d83a3f5a962faf4113375f1266ce73/pom.xml#L1143 defines a standard location for the SpotBugs exclusion file throughout all plugins (`src/spotbugs/spotbugs-excludes.xml`) so there is no need to use a custom name in this plugin. This PR renames the file to the standard name used in other Jenkins plugins and removes the unnecessary customization of the `spotbugs.excludeFilterFile` property.