### PR TITLE
Drop redundant part of example

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -101,10 +101,6 @@ You may also send content in the body of the request, such as for a POST request
 
 [source,groovy]
 ----
-// create payload
-def patchOrg = """
-    {"description": "$description"}
-"""
 httpRequest acceptType: 'APPLICATION_JSON', contentType: 'APPLICATION_JSON',
             httpMode: 'POST', quiet: true,
             requestBody: '''{


### PR DESCRIPTION
Example block for POST "content in the body of the request" started with a separate variable definition for `patchOrg` from the previous example, not relevant in this one.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

A small fix to documentation file, no separate issue or tests.