### PR TITLE
pom.xml: update for new LTS baseline (2.375)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,12 +5,13 @@
 buildPlugin(useContainerAgent: true, configurations: [
   // Test the long-term support end of the compatibility spectrum (i.e., the minimum required
   // Jenkins version).
-  [ platform: 'linux', jdk: '8' ],
+  [ platform: 'linux', jdk: '11', jenkins: '2.375' ],
 
+  // TODO: Un-comment after actual 2.375+ based LTS release
   // Test the common case (i.e., a recent LTS release) on both Linux and Windows.
-  [ platform: 'linux', jdk: '11', jenkins: '2.332.1' ],
-  [ platform: 'windows', jdk: '11', jenkins: '2.332.1' ],
+  //[ platform: 'linux', jdk: '11', jenkins: '2.375.1' ],
+  //[ platform: 'windows', jdk: '11', jenkins: '2.375.1' ],
 
   // Test the bleeding edge of the compatibility spectrum (i.e., the latest supported Java runtime).
-  [ platform: 'linux', jdk: '17', jenkins: '2.342' ],
+  [ platform: 'linux', jdk: '17', jenkins: '2.375' ],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@ THE SOFTWARE.
 		<revision>1.17</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<gitHubRepo>jenkinsci/http-request-plugin</gitHubRepo>
-		<jenkins.version>2.375</jenkins.version>
+		<jenkins.version>2.375.1</jenkins.version>
 		<spotbugs.failOnError>true</spotbugs.failOnError>
 		<spotbugs.threshold>Low</spotbugs.threshold>
 		<hpi.compatibleSinceVersion>1.16</hpi.compatibleSinceVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@ THE SOFTWARE.
 		<revision>1.17</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<gitHubRepo>jenkinsci/http-request-plugin</gitHubRepo>
-		<jenkins.version>2.303.1</jenkins.version>
+		<jenkins.version>2.375</jenkins.version>
 		<spotbugs.failOnError>true</spotbugs.failOnError>
 		<spotbugs.threshold>Low</spotbugs.threshold>
 		<hpi.compatibleSinceVersion>1.16</hpi.compatibleSinceVersion>
@@ -75,8 +75,8 @@ THE SOFTWARE.
 		<dependencies>
 			<dependency>
 				<groupId>io.jenkins.tools.bom</groupId>
-				<artifactId>bom-2.249.x</artifactId>
-				<version>984.vb5eaac999a7e</version>
+				<artifactId>bom-2.375.x</artifactId>
+				<version>1706.vc166d5f429f8</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>
@@ -127,6 +127,17 @@ THE SOFTWARE.
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-job</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>
+			<version>4.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-impl</artifactId>
+			<version>4.0.0</version>
+			<scope>runtime</scope>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
The credentials-plugin (and possibly other dependencies) bumped their baseline requirements in master/main branches, so this plugin can't be built against latest counterparts (even if bumped from 2.303.x to current LTS 2.361.x). Note the new LTS is expected Nov 30 and is expected to be based on 2.375 or later.
* https://github.com/jenkinsci/credentials-plugin/pull/366/commits/399b6d81771adc9f8f808a56fdf6eb375c259cb3

Also reference Jakarta XML directly since we use JDK11+ now, and it is no longer part of core Java: https://stackoverflow.com/a/52502208/4715872

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
