### PR TITLE
Simplify logging with Java 11 StandardCharsets.UTF_8

### DIFF
--- a/src/main/java/jenkins/plugins/http_request/HttpRequestExecution.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestExecution.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
 import java.net.ConnectException;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
@@ -291,11 +290,7 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 
 	private PrintStream logger() {
 		if (localLogger == null) {
-			try {
-				localLogger = new PrintStream(remoteLogger, true, StandardCharsets.UTF_8.name());
-			} catch (UnsupportedEncodingException e) {
-				throw new IllegalStateException(e);
-			}
+			localLogger = new PrintStream(remoteLogger, true, StandardCharsets.UTF_8);
 		}
 		return localLogger;
 	}


### PR DESCRIPTION
changed StandardCharsets.UTF_8.name() to StandardCharsets.UTF_8 in PrintStream logger() method and remove unnecessary exception check .
Improvement for PR #140 

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did