### PR TITLE
Add WebDAV MKCOL method

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -33,7 +33,7 @@ If there is no such setting then it will use the default from global settings. D
 The following powerful features are available in both Pipeline and traditional project types, giving you greater control and flexibility over your builds:
 
 * Programmable HTTP method:
-Choose from a variety of HTTP methods, including GET, POST, PUT, PATCH, DELETE, or HEAD, to suit your project's specific needs.
+Choose from a variety of HTTP methods, including GET, POST, MKCOL, PUT, PATCH, DELETE, OPTIONS, or HEAD, to suit your project's specific needs.
 
 * Programmable range of expected response codes:
 Specify a range of expected response codes for your build, and if the response code falls outside the specified range, the build will fail, saving you time and hassle.
@@ -268,6 +268,24 @@ You can use a Jenkins credential to authenticate the request
 ----
 def response = httpRequest authenticate: 'my-jenkins-credential-id',
                            url: 'https://api.github.com/user/jenkinsci'
+----
+
+A basic WebDAV upload can be built using ``MKCOL`` and ``PUT`` like so:
+
+[source,groovy]
+----
+// create directory aka a collection
+httpRequest authenticate: 'my-jenkins-credential-id',
+            httpMode: 'MKCOL',
+            // on Apache httpd 201 = collection created, 405 = collection already exists
+            validResponseCodes: '201,405',
+            url: "https://example.com/webdav-enabled-server/reports/${version}/"
+// upload a file
+httpRequest authenticate: 'my-jenkins-credential-id',
+            httpMode: 'PUT',
+            validResponseCodes: '201',
+            url: "https://example.com/reports/${version}/your-report-maybe.html",
+            uploadFile: './local/path/to/report.html'
 ----
 
 For details on the Pipeline features, use the Pipeline snippet generator in the Pipeline job 

--- a/src/main/java/jenkins/plugins/http_request/HttpMode.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpMode.java
@@ -12,7 +12,8 @@ public enum HttpMode {
 	PUT,
 	DELETE,
 	OPTIONS,
-	PATCH;
+	PATCH,
+	MKCOL;
 
 	public static ListBoxModel getFillItems() {
 		ListBoxModel items = new ListBoxModel();

--- a/src/main/java/jenkins/plugins/http_request/util/HttpClientUtil.java
+++ b/src/main/java/jenkins/plugins/http_request/util/HttpClientUtil.java
@@ -62,6 +62,8 @@ public class HttpClientUtil {
 			http = new HttpPatch(uri);
         } else if (requestAction.getMode() == HttpMode.OPTIONS) {
         	return new HttpOptions(getUrlWithParams(requestAction));
+		} else if (requestAction.getMode() == HttpMode.MKCOL) {
+			return new HttpMkcol(uri);
 		} else { //default post
 			http = new HttpPost(uri);
 		}

--- a/src/main/java/jenkins/plugins/http_request/util/HttpMkcol.java
+++ b/src/main/java/jenkins/plugins/http_request/util/HttpMkcol.java
@@ -1,0 +1,19 @@
+package jenkins.plugins.http_request.util;
+
+import java.net.URI;
+
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+
+public class HttpMkcol extends HttpEntityEnclosingRequestBase {
+	public final static String METHOD_NAME = "MKCOL";
+
+	public HttpMkcol(final String uri) {
+		super();
+		setURI(URI.create(uri));
+	}
+
+	@Override
+	public String getMethod() {
+		return METHOD_NAME;
+	}
+}


### PR DESCRIPTION
MKCOL and PUT allow for write only WebDAV use to upload artifacts during the build

<!-- Please describe your pull request here. -->
Add the WebDAV MKCOL method to the allowed list of methods. With it this plugin allows write only use of a WebDav server to upload artifacts (using `MKCOL` and `PUT`).

### Testing done
The existing unittests verify the basic functionality.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira (none)
- [X] Link to relevant pull requests, esp. upstream and downstream changes (none)
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
