### PR TITLE
JENKINS-63248: Add label attribute to httpRequest step

### DIFF
--- a/src/main/resources/jenkins/plugins/http_request/HttpRequestStep/config.jelly
+++ b/src/main/resources/jenkins/plugins/http_request/HttpRequestStep/config.jelly
@@ -9,7 +9,9 @@
     <f:entry field="ignoreSslErrors" title="Ignore Ssl errors?" help="/plugin/http_request/help-ignoreSslErrors.html">
         <f:booleanRadio />
     </f:entry>
-
+	<f:entry field="label" title="${%Label}">
+		<f:textbox/>
+	</f:entry>
     <f:advanced>
         <f:entry field="httpProxy" title="Http Proxy" help="/plugin/http_request/help-httpProxy.html">
             <f:textbox />

--- a/src/main/resources/jenkins/plugins/http_request/HttpRequestStep/help-label.html
+++ b/src/main/resources/jenkins/plugins/http_request/HttpRequestStep/help-label.html
@@ -1,0 +1,4 @@
+<div>
+	Label to be displayed in the pipeline step view and blue ocean details for the step instead of the step type.
+	The view contains domain specifics instead of repeated step type.
+</div>

--- a/src/test/java/jenkins/plugins/http_request/HttpRequestStepRoundTripTest.java
+++ b/src/test/java/jenkins/plugins/http_request/HttpRequestStepRoundTripTest.java
@@ -49,6 +49,8 @@ public class HttpRequestStepRoundTripTest {
         configRoundTrip(before);
         before.setConsoleLogResponseBody(false);
         configRoundTrip(before);
+		before.setLabel("GET real");
+		configRoundTrip(before);
     }
 
     @Test
@@ -96,7 +98,8 @@ public class HttpRequestStepRoundTripTest {
         j.assertEqualBeans(before, after, "multipartName");
         j.assertEqualBeans(before, after, "timeout");
         j.assertEqualBeans(before, after, "consoleLogResponseBody");
-        j.assertEqualBeans(before, after, "authentication");
+		j.assertEqualBeans(before, after, "authentication");
+        j.assertEqualBeans(before, after, "label");
 
         // Custom header check
         assertEquals(before.getCustomHeaders().size(),after.getCustomHeaders().size());


### PR DESCRIPTION
Label attribute displayed in the pipeline steps and blue ocean views.  Default label attribute is the http mode.

[JENKINS-63248](https://issues.jenkins.io/browse/JENKINS-63248)

### Testing done

Unit tests
Visual inspection of blue ocean

### Submitter checklist
```[tasklist]
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
