### PR TITLE
Require Jenkins 2.426.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,9 @@ THE SOFTWARE.
 		<revision>1.19</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<gitHubRepo>jenkinsci/http-request-plugin</gitHubRepo>
-                <jenkins.version>2.361.4</jenkins.version>
+                <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+                <jenkins.baseline>2.426</jenkins.baseline>
+                <jenkins.version>${jenkins.baseline}.3</jenkins.version>
 		<spotbugs.failOnError>true</spotbugs.failOnError>
 		<spotbugs.threshold>Low</spotbugs.threshold>
 		<hpi.compatibleSinceVersion>1.16</hpi.compatibleSinceVersion>
@@ -75,8 +77,8 @@ THE SOFTWARE.
 		<dependencies>
 			<dependency>
 				<groupId>io.jenkins.tools.bom</groupId>
-                                <artifactId>bom-2.361.x</artifactId>
-                                <version>2102.v854b_fec19c92</version>
+                                <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                                <version>3208.vb_21177d4b_cd9</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>


### PR DESCRIPTION
## Require Jenkins 2.426.3 or newer

79% of the installations of the most recent release (1.18 - a year ago) are running 2.426.3 or newer as noted by [plugin installation statistics](https://stats.jenkins.io/pluginversions/http_request.html)

Jenkins 2.426.3 includes a fix for a critical security vulnerability.  Users should upgrade to 2.426.3 or newer in order to have that critical fix.

### Testing done

Confirmed that automated tests pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
