### PR TITLE
[JENKINS-68154] Add Custom headers with special characters in their names

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -150,6 +150,29 @@ def response =  httpRequest customHeaders: [[maskValue: true, name: 'foo', value
                             url: 'https://api.github.com/orgs/${orgName}'
 ----
 
+You can set custom headers with special characters in their names (such as hyphens) using a Map:
+
+[source,groovy]
+----
+def headerMap = ['my-custom-header-with-hyphen-separator': 'headerValue']
+def response = httpRequest headersMap: headerMap, 
+                           url: 'https://api.github.com/orgs/${orgName}'
+----
+
+Alternatively, you can use the static factory method:
+
+[source,groovy]
+----
+import jenkins.plugins.http_request.util.HttpRequestNameValuePair
+
+def headers = [
+  HttpRequestNameValuePair.create('my-custom-header-with-hyphen-separator', 'value1', false),
+  HttpRequestNameValuePair.create('another-header', 'value2', true) // true to mask the value
+]
+def response = httpRequest customHeaders: headers,
+                           url: 'https://api.github.com/orgs/${orgName}'
+----
+
 You can send ``multipart/form-data`` forms:
 
 [source,groovy]

--- a/src/main/java/jenkins/plugins/http_request/HttpRequest.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequest.java
@@ -247,7 +247,7 @@ public class HttpRequest extends Builder {
 
 	/**
 	 * Set custom headers from a Map to support headers with special characters in their names.
-	 * This is an alternative to using the List<HttpRequestNameValuePair> that makes it easier
+	 * This is an alternative to using the List&lt;HttpRequestNameValuePair&gt; that makes it easier
 	 * to define headers with special characters in the name such as hyphens.
 	 * 
 	 * @param headerMap Map of header names to values

--- a/src/main/java/jenkins/plugins/http_request/HttpRequest.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequest.java
@@ -2,6 +2,11 @@ package jenkins.plugins.http_request;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -238,6 +243,24 @@ public class HttpRequest extends Builder {
 	@DataBoundSetter
 	public void setCustomHeaders(List<HttpRequestNameValuePair> customHeaders) {
 		this.customHeaders = customHeaders;
+	}
+
+	/**
+	 * Set custom headers from a Map to support headers with special characters in their names.
+	 * This is an alternative to using the List<HttpRequestNameValuePair> that makes it easier
+	 * to define headers with special characters in the name such as hyphens.
+	 * 
+	 * @param headerMap Map of header names to values
+	 */
+	@DataBoundSetter
+	public void setHeadersMap(Map<String, String> headerMap) {
+		List<HttpRequestNameValuePair> headers = new ArrayList<>();
+		if (headerMap != null) {
+			for (Map.Entry<String, String> entry : headerMap.entrySet()) {
+				headers.add(new HttpRequestNameValuePair(entry));
+			}
+		}
+		this.customHeaders = headers;
 	}
 
 	public List<HttpRequestFormDataPart> getFormData() {

--- a/src/main/java/jenkins/plugins/http_request/HttpRequestStep.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestStep.java
@@ -207,7 +207,7 @@ public final class HttpRequestStep extends Step {
 
     /**
      * Set custom headers from a Map to support headers with special characters in their names.
-     * This is an alternative to using the List<HttpRequestNameValuePair> that makes it easier
+     * This is an alternative to using the List&lt;HttpRequestNameValuePair&gt; that makes it easier
      * to define headers with special characters in the name such as hyphens.
      * 
      * @param headerMap Map of header names to values

--- a/src/main/java/jenkins/plugins/http_request/HttpRequestStep.java
+++ b/src/main/java/jenkins/plugins/http_request/HttpRequestStep.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -202,6 +203,24 @@ public final class HttpRequestStep extends Step {
     @DataBoundSetter
     public void setCustomHeaders(List<HttpRequestNameValuePair> customHeaders) {
         this.customHeaders = customHeaders;
+    }
+
+    /**
+     * Set custom headers from a Map to support headers with special characters in their names.
+     * This is an alternative to using the List<HttpRequestNameValuePair> that makes it easier
+     * to define headers with special characters in the name such as hyphens.
+     * 
+     * @param headerMap Map of header names to values
+     */
+    @DataBoundSetter
+    public void setHeadersMap(Map<String, String> headerMap) {
+        List<HttpRequestNameValuePair> headers = new ArrayList<>();
+        if (headerMap != null) {
+            for (Map.Entry<String, String> entry : headerMap.entrySet()) {
+                headers.add(new HttpRequestNameValuePair(entry));
+            }
+        }
+        this.customHeaders = headers;
     }
 
     public List<HttpRequestNameValuePair> getCustomHeaders() {

--- a/src/main/java/jenkins/plugins/http_request/util/HttpRequestNameValuePair.java
+++ b/src/main/java/jenkins/plugins/http_request/util/HttpRequestNameValuePair.java
@@ -1,9 +1,11 @@
 package jenkins.plugins.http_request.util;
 
 import java.io.Serializable;
+import java.util.Map;
 
 import org.apache.http.NameValuePair;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -21,7 +23,7 @@ public class HttpRequestNameValuePair extends AbstractDescribableImpl<HttpReques
 	private static final long serialVersionUID = -5179602567301232134L;
 	private final String name;
     private final String value;
-    private final boolean maskValue;
+    private boolean maskValue;
 
     @DataBoundConstructor
     public HttpRequestNameValuePair(String name, String value, boolean maskValue) {
@@ -32,6 +34,26 @@ public class HttpRequestNameValuePair extends AbstractDescribableImpl<HttpReques
 
     public HttpRequestNameValuePair(String name, String value) {
         this(name, value, false);
+    }
+    
+    /**
+     * Constructor that accepts a Map.Entry to support headers with special characters in their names
+     * @param entry Map.Entry containing the header name and value
+     */
+    public HttpRequestNameValuePair(Map.Entry<String, String> entry) {
+        this(entry.getKey(), entry.getValue(), false);
+    }
+    
+    /**
+     * Constructor that accepts a header name and value directly
+     * This allows headers with special characters (like hyphens) to be created more easily
+     * @param name The header name (can contain special characters)
+     * @param value The header value
+     * @param maskValue Whether to mask the value in logs
+     * @return A new HttpRequestNameValuePair
+     */
+    public static HttpRequestNameValuePair create(String name, String value, boolean maskValue) {
+        return new HttpRequestNameValuePair(name, value, maskValue);
     }
 
     public String getName() {
@@ -44,6 +66,11 @@ public class HttpRequestNameValuePair extends AbstractDescribableImpl<HttpReques
 
     public boolean getMaskValue() {
         return maskValue;
+    }
+    
+    @DataBoundSetter
+    public void setMaskValue(boolean maskValue) {
+        this.maskValue = maskValue;
     }
 
     @Extension

--- a/src/test/java/jenkins/plugins/http_request/HttpRequestStepSpecialHeadersTest.java
+++ b/src/test/java/jenkins/plugins/http_request/HttpRequestStepSpecialHeadersTest.java
@@ -1,0 +1,85 @@
+package jenkins.plugins.http_request;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import hudson.model.Result;
+import jenkins.plugins.http_request.util.HttpRequestNameValuePair;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test for HttpRequest with headers that contain special characters
+ */
+public class HttpRequestStepSpecialHeadersTest {
+
+    @Rule
+    public final JenkinsRule j = new JenkinsRule();
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    /**
+     * Test that we can use headers with special characters in their names
+     */
+    @Test
+    public void testSpecialCharactersInHeaderNamesUsingMap() throws Exception {
+        // Create a test pipeline that uses the new setHeadersMap method
+        String script = "node {\n" +
+                "  def headerMap = ['my-custom-header-with-hyphen-separator': 'test-value']\n" +
+                "  def response = httpRequest url: 'http://example.com', headersMap: headerMap\n" +
+                "  echo \"Response: ${response.content}\"\n" +
+                "}";
+
+        WorkflowJob project = j.createProject(WorkflowJob.class);
+        project.setDefinition(new CpsFlowDefinition(script, true));
+        
+        // The actual HTTP request to example.com actually works in the test environment
+        WorkflowRun run = project.scheduleBuild2(0).get();
+        j.assertBuildStatusSuccess(run);
+        j.assertLogContains("my-custom-header-with-hyphen-separator: test-value", run);
+    }
+    
+    /**
+     * Test that we can create headers with special characters using the static factory method
+     */
+    @Test
+    public void testSpecialCharactersInHeaderNamesUsingCreate() throws Exception {
+        // Test the static factory method create()
+        HttpRequestNameValuePair header = HttpRequestNameValuePair.create(
+                "my-custom-header-with-hyphen-separator", 
+                "test-value", 
+                false);
+        
+        assertEquals("my-custom-header-with-hyphen-separator", header.getName());
+        assertEquals("test-value", header.getValue());
+        assertEquals(false, header.getMaskValue());
+    }
+    
+    /**
+     * Test that we can create headers with special characters using the Map.Entry constructor
+     */
+    @Test
+    public void testSpecialCharactersInHeaderNamesUsingMapEntry() throws Exception {
+        // Create a map with a header that contains special characters
+        Map<String, String> headerMap = new HashMap<>();
+        headerMap.put("my-custom-header-with-hyphen-separator", "test-value");
+        
+        // Create a header using the entry from the map
+        Map.Entry<String, String> entry = headerMap.entrySet().iterator().next();
+        HttpRequestNameValuePair header = new HttpRequestNameValuePair(entry);
+        
+        assertEquals("my-custom-header-with-hyphen-separator", header.getName());
+        assertEquals("test-value", header.getValue());
+    }
+} 


### PR DESCRIPTION
## Description

This PR addresses [JENKINS-68154](https://issues.jenkins.io/browse/JENKINS-68154)  & improvement on [PR - 194](https://github.com/jenkinsci/http-request-plugin/pull/194) to allow custom headers with special characters in their names, such as hyphens.

## Changes Done

### In HttpRequestNameValuePair.java:
- Added a new constructor that accepts Map.Entry to support headers with special characters
- Added a static factory method for easier creation of headers with special characters
- Added DataBoundSetter for maskValue property

### In HttpRequestStep.java:
- Added a new method to set custom headers using a Map (headersMap)
- This allows for simpler syntax when using headers with special characters

### In HttpRequest.java:
- Added a similar method to set custom headers using a Map
- Ensures consistent API between freestyle and pipeline jobs

### In README.adoc:
- Added documentation for the new feature with examples showing how to use it

### Added tests:
- Created HttpRequestStepSpecialHeadersTest.java with tests for:
  - Using Map syntax for headers with special characters
  - Using the static factory method
  - Using the Map.Entry constructor

### Testing done
 - All tests pass successfully
 - Manually verified with example headers containing hyphens in local jenkins controller
 - Pipeline I tested for customHeaders:

```bash
pipeline {
    agent any
    stages {
        stage('Test HTTP Request with Special Header Names') {
            steps {
                script {
                    echo "Testing HTTP Request with special characters in header names"
                    
                    def headerName1 = 'my-custom-header-with-hyphen-separator'
                    def headerValue1 = 'test-value-1'
                    def headerName2 = 'another-header-with-hyphens'
                    def headerValue2 = 'test-value-2'
                    
                    // Create a map of headers with special characters
                    def headers = [
                        "${headerName1}": "${headerValue1}",
                        "${headerName2}": "${headerValue2}"
                    ]
                    
                    // Make an HTTP request with these headers
                    def response = httpRequest(
                        url: 'https://httpbin.org/headers', // This endpoint returns the headers it receives
                        headersMap: headers  // Using our new headersMap parameter
                    )
                    
                    // Log the response
                    echo "Response status: ${response.status}"
                    echo "Response content: ${response.content}"
                    
                    // The response from httpbin.org has capitalized header names
                    // For example: 'my-custom-header-with-hyphen-separator' becomes 'My-Custom-Header-With-Hyphen-Separator'
                    def responseContent = response.content.toLowerCase()
                    assert responseContent.contains(headerValue1.toLowerCase())
                    assert responseContent.contains(headerValue2.toLowerCase())
                    
                    echo "Custom headers with special characters were successfully used!"
                }
            }
        }
    }
}
```
 - Its build console output

```bash
Started by user unknown or anonymous
[Pipeline] Start of Pipeline
[Pipeline] node
Running on Jenkins
 in /home/pratik_0112/GSoC/http-request-plugin/work/workspace/TestCustomHeaders
[Pipeline] {
[Pipeline] stage
[Pipeline] { (Test HTTP Request with Special Header Names)
[Pipeline] script
[Pipeline] {
[Pipeline] echo
Testing HTTP Request with special characters in header names
[Pipeline] httpRequest
HttpMethod: GET
URL: https://httpbin.org/headers
my-custom-header-with-hyphen-separator: test-value-1
another-header-with-hyphens: test-value-2
Sending request to url: https://httpbin.org/headers
Response Code: HTTP/1.1 200 OK
Success: Status code 200 is in the accepted range: 100:399
[Pipeline] echo
Response status: 200
[Pipeline] echo
Response content: {
  "headers": {
    "Accept-Encoding": "gzip,deflate", 
    "Another-Header-With-Hyphens": "test-value-2", 
    "Host": "httpbin.org", 
    "My-Custom-Header-With-Hyphen-Separator": "test-value-1", 
    "User-Agent": "Apache-HttpClient/4.5.14 (Java/17.0.14)", 
    "X-Amzn-Trace-Id": "Root=1-67ebbb1f-6a9bd01214701c9d7c91565a"
  }
}

[Pipeline] echo
Custom headers with special characters were successfully used!
[Pipeline] }
[Pipeline] // script
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
Finished: SUCCESS

```
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

